### PR TITLE
Add auxiliary equality block decomposition

### DIFF
--- a/src/auxiliary_preprocessing.rs
+++ b/src/auxiliary_preprocessing.rs
@@ -8,6 +8,26 @@ use crate::problem::NlpProblem;
 use std::collections::VecDeque;
 
 #[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct EqualityBlock {
+    pub(crate) rows: Vec<usize>,
+    pub(crate) vars: Vec<usize>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum BlockTriangularizationError {
+    NonSquare {
+        rows: usize,
+        vars: usize,
+    },
+    ImperfectMatching {
+        unmatched_rows: Vec<usize>,
+        unmatched_vars: Vec<usize>,
+    },
+}
+
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub(crate) struct EqualityIncidence {
     pub(crate) n_vars: usize,
@@ -214,6 +234,198 @@ impl EqualityIncidence {
         }
     }
 
+    #[allow(dead_code)]
+    pub(crate) fn connected_components(
+        &self,
+        selected_local_rows: &[usize],
+        selected_vars: &[usize],
+    ) -> Vec<EqualityBlock> {
+        let selected_local_rows =
+            sorted_unique_bounded(selected_local_rows, self.row_adj_vars.len());
+        let selected_vars = sorted_unique_bounded(selected_vars, self.n_vars);
+        let mut row_selected = vec![false; self.row_adj_vars.len()];
+        let mut var_selected = vec![false; self.n_vars];
+        for &row in &selected_local_rows {
+            row_selected[row] = true;
+        }
+        for &var in &selected_vars {
+            var_selected[var] = true;
+        }
+
+        let (row_adj_vars, var_adj_rows) = self.deterministic_adjacency();
+        let mut row_seen = vec![false; self.row_adj_vars.len()];
+        let mut var_seen = vec![false; self.n_vars];
+        let mut components = Vec::new();
+
+        for &start_row in &selected_local_rows {
+            if row_seen[start_row] {
+                continue;
+            }
+            components.push(self.connected_component_from(
+                BipartiteNode::Row(start_row),
+                &row_selected,
+                &var_selected,
+                &row_adj_vars,
+                &var_adj_rows,
+                &mut row_seen,
+                &mut var_seen,
+            ));
+        }
+
+        for &start_var in &selected_vars {
+            if var_seen[start_var] {
+                continue;
+            }
+            components.push(self.connected_component_from(
+                BipartiteNode::Var(start_var),
+                &row_selected,
+                &var_selected,
+                &row_adj_vars,
+                &var_adj_rows,
+                &mut row_seen,
+                &mut var_seen,
+            ));
+        }
+
+        components.sort_by_key(equality_block_sort_key);
+        components
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn block_triangular_decomposition(
+        &self,
+        selected_local_rows: &[usize],
+        selected_vars: &[usize],
+    ) -> Result<Vec<EqualityBlock>, BlockTriangularizationError> {
+        let selected_local_rows =
+            sorted_unique_bounded(selected_local_rows, self.row_adj_vars.len());
+        let selected_vars = sorted_unique_bounded(selected_vars, self.n_vars);
+        if selected_local_rows.len() != selected_vars.len() {
+            return Err(BlockTriangularizationError::NonSquare {
+                rows: selected_local_rows.len(),
+                vars: selected_vars.len(),
+            });
+        }
+
+        let (row_adj_vars, _) = self.deterministic_adjacency();
+        let mut compact_var_for_global = vec![None; self.n_vars];
+        for (compact_var, &global_var) in selected_vars.iter().enumerate() {
+            compact_var_for_global[global_var] = Some(compact_var);
+        }
+
+        let restricted_row_adj_vars: Vec<Vec<usize>> = selected_local_rows
+            .iter()
+            .map(|&row| {
+                row_adj_vars[row]
+                    .iter()
+                    .filter_map(|&var| compact_var_for_global[var])
+                    .collect()
+            })
+            .collect();
+
+        let matching = hopcroft_karp(selected_vars.len(), &restricted_row_adj_vars);
+        if !matching.unmatched_rows.is_empty() || !matching.unmatched_vars.is_empty() {
+            return Err(BlockTriangularizationError::ImperfectMatching {
+                unmatched_rows: matching
+                    .unmatched_rows
+                    .iter()
+                    .map(|&row| self.row_global[selected_local_rows[row]])
+                    .collect(),
+                unmatched_vars: matching
+                    .unmatched_vars
+                    .iter()
+                    .map(|&var| selected_vars[var])
+                    .collect(),
+            });
+        }
+
+        let mut matched_row_for_compact_var = vec![None; selected_vars.len()];
+        for (row, &matched_var) in matching.row_to_var.iter().enumerate() {
+            if let Some(var) = matched_var {
+                matched_row_for_compact_var[var] = Some(row);
+            }
+        }
+
+        let mut dependencies = vec![Vec::new(); selected_local_rows.len()];
+        for (row, adj_vars) in restricted_row_adj_vars.iter().enumerate() {
+            for &var in adj_vars {
+                if matching.row_to_var[row] == Some(var) {
+                    continue;
+                }
+                if let Some(predecessor_row) = matched_row_for_compact_var[var] {
+                    dependencies[predecessor_row].push(row);
+                }
+            }
+        }
+        for adj in &mut dependencies {
+            adj.sort_unstable();
+            adj.dedup();
+        }
+
+        let components = tarjan_strongly_connected_components(&dependencies);
+        Ok(topologically_order_blocks(
+            &components,
+            &dependencies,
+            &selected_local_rows,
+            &selected_vars,
+            &matching.row_to_var,
+            &self.row_global,
+        ))
+    }
+
+    fn connected_component_from(
+        &self,
+        start: BipartiteNode,
+        row_selected: &[bool],
+        var_selected: &[bool],
+        row_adj_vars: &[Vec<usize>],
+        var_adj_rows: &[Vec<usize>],
+        row_seen: &mut [bool],
+        var_seen: &mut [bool],
+    ) -> EqualityBlock {
+        let mut queue = VecDeque::new();
+        let mut rows = Vec::new();
+        let mut vars = Vec::new();
+
+        match start {
+            BipartiteNode::Row(row) => {
+                row_seen[row] = true;
+                queue.push_back(BipartiteNode::Row(row));
+            }
+            BipartiteNode::Var(var) => {
+                var_seen[var] = true;
+                queue.push_back(BipartiteNode::Var(var));
+            }
+        }
+
+        while let Some(node) = queue.pop_front() {
+            match node {
+                BipartiteNode::Row(row) => {
+                    rows.push(self.row_global[row]);
+                    for &var in &row_adj_vars[row] {
+                        if var_selected[var] && !var_seen[var] {
+                            var_seen[var] = true;
+                            queue.push_back(BipartiteNode::Var(var));
+                        }
+                    }
+                }
+                BipartiteNode::Var(var) => {
+                    vars.push(var);
+                    for &row in &var_adj_rows[var] {
+                        if row_selected[row] && !row_seen[row] {
+                            row_seen[row] = true;
+                            queue.push_back(BipartiteNode::Row(row));
+                        }
+                    }
+                }
+            }
+        }
+
+        rows.sort_unstable();
+        vars.sort_unstable();
+        EqualityBlock { rows, vars }
+    }
+
     fn deterministic_adjacency(&self) -> (Vec<Vec<usize>>, Vec<Vec<usize>>) {
         let mut row_adj_vars = Vec::with_capacity(self.row_adj_vars.len());
         let mut var_adj_rows = vec![Vec::new(); self.n_vars];
@@ -240,6 +452,24 @@ impl EqualityIncidence {
 
         (row_adj_vars, var_adj_rows)
     }
+}
+
+fn sorted_unique_bounded(indices: &[usize], upper_bound: usize) -> Vec<usize> {
+    let mut indices: Vec<_> = indices
+        .iter()
+        .copied()
+        .filter(|&idx| idx < upper_bound)
+        .collect();
+    indices.sort_unstable();
+    indices.dedup();
+    indices
+}
+
+fn equality_block_sort_key(block: &EqualityBlock) -> (usize, usize) {
+    (
+        block.rows.first().copied().unwrap_or(usize::MAX),
+        block.vars.first().copied().unwrap_or(usize::MAX),
+    )
 }
 
 fn hopcroft_karp(n_vars: usize, row_adj_vars: &[Vec<usize>]) -> BipartiteMatching {
@@ -372,6 +602,149 @@ fn indices_where(flags: &[bool]) -> Vec<usize> {
         .enumerate()
         .filter_map(|(idx, &flag)| flag.then_some(idx))
         .collect()
+}
+
+fn tarjan_strongly_connected_components(adj: &[Vec<usize>]) -> Vec<Vec<usize>> {
+    let n = adj.len();
+    let mut next_index = 0usize;
+    let mut index = vec![None; n];
+    let mut lowlink = vec![0usize; n];
+    let mut stack = Vec::new();
+    let mut on_stack = vec![false; n];
+    let mut components = Vec::new();
+
+    fn strong_connect(
+        node: usize,
+        adj: &[Vec<usize>],
+        next_index: &mut usize,
+        index: &mut [Option<usize>],
+        lowlink: &mut [usize],
+        stack: &mut Vec<usize>,
+        on_stack: &mut [bool],
+        components: &mut Vec<Vec<usize>>,
+    ) {
+        index[node] = Some(*next_index);
+        lowlink[node] = *next_index;
+        *next_index += 1;
+        stack.push(node);
+        on_stack[node] = true;
+
+        for &next in &adj[node] {
+            if index[next].is_none() {
+                strong_connect(
+                    next, adj, next_index, index, lowlink, stack, on_stack, components,
+                );
+                lowlink[node] = lowlink[node].min(lowlink[next]);
+            } else if on_stack[next] {
+                lowlink[node] = lowlink[node].min(index[next].expect("visited node has index"));
+            }
+        }
+
+        if lowlink[node] == index[node].expect("visited node has index") {
+            let mut component = Vec::new();
+            while let Some(member) = stack.pop() {
+                on_stack[member] = false;
+                component.push(member);
+                if member == node {
+                    break;
+                }
+            }
+            component.sort_unstable();
+            components.push(component);
+        }
+    }
+
+    for node in 0..n {
+        if index[node].is_none() {
+            strong_connect(
+                node,
+                adj,
+                &mut next_index,
+                &mut index,
+                &mut lowlink,
+                &mut stack,
+                &mut on_stack,
+                &mut components,
+            );
+        }
+    }
+
+    components
+}
+
+fn topologically_order_blocks(
+    components: &[Vec<usize>],
+    dependencies: &[Vec<usize>],
+    selected_local_rows: &[usize],
+    selected_vars: &[usize],
+    row_to_compact_var: &[Option<usize>],
+    row_global: &[usize],
+) -> Vec<EqualityBlock> {
+    let mut component_for_row = vec![0; selected_local_rows.len()];
+    for (component, rows) in components.iter().enumerate() {
+        for &row in rows {
+            component_for_row[row] = component;
+        }
+    }
+
+    let mut component_edges = vec![Vec::new(); components.len()];
+    let mut indegree = vec![0usize; components.len()];
+    for (from_row, edges) in dependencies.iter().enumerate() {
+        let from_component = component_for_row[from_row];
+        for &to_row in edges {
+            let to_component = component_for_row[to_row];
+            if from_component != to_component {
+                component_edges[from_component].push(to_component);
+            }
+        }
+    }
+    for edges in &mut component_edges {
+        edges.sort_unstable();
+        edges.dedup();
+        for &to_component in edges.iter() {
+            indegree[to_component] += 1;
+        }
+    }
+
+    let blocks: Vec<_> = components
+        .iter()
+        .map(|rows| {
+            let mut block_rows: Vec<_> = rows
+                .iter()
+                .map(|&row| row_global[selected_local_rows[row]])
+                .collect();
+            let mut block_vars: Vec<_> = rows
+                .iter()
+                .filter_map(|&row| row_to_compact_var[row].map(|var| selected_vars[var]))
+                .collect();
+            block_rows.sort_unstable();
+            block_vars.sort_unstable();
+            EqualityBlock {
+                rows: block_rows,
+                vars: block_vars,
+            }
+        })
+        .collect();
+
+    let mut ordered_blocks = Vec::with_capacity(blocks.len());
+    let mut ready: Vec<_> = (0..components.len())
+        .filter(|&component| indegree[component] == 0)
+        .collect();
+    ready.sort_by_key(|&component| equality_block_sort_key(&blocks[component]));
+
+    while !ready.is_empty() {
+        let component = ready.remove(0);
+        ordered_blocks.push(blocks[component].clone());
+        for &next in &component_edges[component] {
+            indegree[next] -= 1;
+            if indegree[next] == 0 {
+                ready.push(next);
+            }
+        }
+        ready.sort_by_key(|&component| equality_block_sort_key(&blocks[component]));
+    }
+
+    ordered_blocks
 }
 
 #[cfg(test)]
@@ -695,5 +1068,170 @@ mod tests {
         assert_eq!(dm.square_vars, vec![0, 1]);
         assert_eq!(dm.underconstrained_rows, vec![4]);
         assert_eq!(dm.underconstrained_vars, vec![3, 4]);
+    }
+
+    #[test]
+    fn connected_components_split_selected_independent_systems() {
+        let bounds = equality_bounds(4);
+        let problem = graph_problem(5, &bounds, &[(0, 0), (1, 2), (1, 1), (2, 3), (3, 4)]);
+        let inc = EqualityIncidence::from_problem(&problem, TOL);
+
+        let components = inc.connected_components(&[3, 1, 0, 2], &[4, 0, 3, 2, 1]);
+
+        assert_eq!(
+            components,
+            vec![
+                EqualityBlock {
+                    rows: vec![0],
+                    vars: vec![0],
+                },
+                EqualityBlock {
+                    rows: vec![1],
+                    vars: vec![1, 2],
+                },
+                EqualityBlock {
+                    rows: vec![2],
+                    vars: vec![3],
+                },
+                EqualityBlock {
+                    rows: vec![3],
+                    vars: vec![4],
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn connected_components_return_global_equality_rows() {
+        let problem = graph_problem(2, &[(0.0, 1.0), (2.0, 2.0), (3.0, 3.0)], &[(1, 0), (2, 1)]);
+        let inc = EqualityIncidence::from_problem(&problem, TOL);
+
+        let components = inc.connected_components(&[0, 1], &[0, 1]);
+
+        assert_eq!(
+            components,
+            vec![
+                EqualityBlock {
+                    rows: vec![1],
+                    vars: vec![0],
+                },
+                EqualityBlock {
+                    rows: vec![2],
+                    vars: vec![1],
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn btd_splits_independent_square_systems() {
+        let bounds = equality_bounds(3);
+        let problem = graph_problem(3, &bounds, &[(2, 2), (0, 0), (1, 1)]);
+        let inc = EqualityIncidence::from_problem(&problem, TOL);
+
+        let blocks = inc
+            .block_triangular_decomposition(&[2, 0, 1], &[2, 0, 1])
+            .unwrap();
+
+        assert_eq!(
+            blocks,
+            vec![
+                EqualityBlock {
+                    rows: vec![0],
+                    vars: vec![0],
+                },
+                EqualityBlock {
+                    rows: vec![1],
+                    vars: vec![1],
+                },
+                EqualityBlock {
+                    rows: vec![2],
+                    vars: vec![2],
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn btd_orders_triangular_system_upstream_to_downstream() {
+        let bounds = equality_bounds(3);
+        let problem = graph_problem(3, &bounds, &[(2, 2), (1, 1), (1, 0), (0, 0), (2, 1)]);
+        let inc = EqualityIncidence::from_problem(&problem, TOL);
+
+        let blocks = inc
+            .block_triangular_decomposition(&[2, 1, 0], &[2, 1, 0])
+            .unwrap();
+
+        assert_eq!(
+            blocks,
+            vec![
+                EqualityBlock {
+                    rows: vec![0],
+                    vars: vec![0],
+                },
+                EqualityBlock {
+                    rows: vec![1],
+                    vars: vec![1],
+                },
+                EqualityBlock {
+                    rows: vec![2],
+                    vars: vec![2],
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn btd_returns_cyclic_square_system_as_one_block() {
+        let bounds = equality_bounds(2);
+        let problem = graph_problem(2, &bounds, &[(0, 1), (1, 0), (0, 0), (1, 1)]);
+        let inc = EqualityIncidence::from_problem(&problem, TOL);
+
+        let blocks = inc
+            .block_triangular_decomposition(&[0, 1], &[0, 1])
+            .unwrap();
+
+        assert_eq!(
+            blocks,
+            vec![EqualityBlock {
+                rows: vec![0, 1],
+                vars: vec![0, 1],
+            }]
+        );
+    }
+
+    #[test]
+    fn btd_rejects_non_square_input() {
+        let bounds = equality_bounds(1);
+        let problem = graph_problem(2, &bounds, &[(0, 0), (0, 1)]);
+        let inc = EqualityIncidence::from_problem(&problem, TOL);
+
+        let err = inc
+            .block_triangular_decomposition(&[0], &[0, 1])
+            .unwrap_err();
+
+        assert_eq!(
+            err,
+            BlockTriangularizationError::NonSquare { rows: 1, vars: 2 }
+        );
+    }
+
+    #[test]
+    fn btd_rejects_square_but_imperfectly_matched_input() {
+        let bounds = equality_bounds(2);
+        let problem = graph_problem(2, &bounds, &[(0, 0), (1, 0)]);
+        let inc = EqualityIncidence::from_problem(&problem, TOL);
+
+        let err = inc
+            .block_triangular_decomposition(&[0, 1], &[0, 1])
+            .unwrap_err();
+
+        assert_eq!(
+            err,
+            BlockTriangularizationError::ImperfectMatching {
+                unmatched_rows: vec![1],
+                unmatched_vars: vec![1],
+            }
+        );
     }
 }

--- a/src/auxiliary_preprocessing.rs
+++ b/src/auxiliary_preprocessing.rs
@@ -5,7 +5,8 @@
 //! decomposition or transform API.
 
 use crate::problem::NlpProblem;
-use std::collections::VecDeque;
+use std::cmp::Reverse;
+use std::collections::{BinaryHeap, VecDeque};
 
 #[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -605,67 +606,77 @@ fn indices_where(flags: &[bool]) -> Vec<usize> {
 }
 
 fn tarjan_strongly_connected_components(adj: &[Vec<usize>]) -> Vec<Vec<usize>> {
+    struct Frame {
+        node: usize,
+        next_edge: usize,
+    }
+
     let n = adj.len();
     let mut next_index = 0usize;
     let mut index = vec![None; n];
     let mut lowlink = vec![0usize; n];
-    let mut stack = Vec::new();
+    let mut scc_stack = Vec::new();
     let mut on_stack = vec![false; n];
     let mut components = Vec::new();
 
-    fn strong_connect(
-        node: usize,
-        adj: &[Vec<usize>],
-        next_index: &mut usize,
-        index: &mut [Option<usize>],
-        lowlink: &mut [usize],
-        stack: &mut Vec<usize>,
-        on_stack: &mut [bool],
-        components: &mut Vec<Vec<usize>>,
-    ) {
-        index[node] = Some(*next_index);
-        lowlink[node] = *next_index;
-        *next_index += 1;
-        stack.push(node);
-        on_stack[node] = true;
-
-        for &next in &adj[node] {
-            if index[next].is_none() {
-                strong_connect(
-                    next, adj, next_index, index, lowlink, stack, on_stack, components,
-                );
-                lowlink[node] = lowlink[node].min(lowlink[next]);
-            } else if on_stack[next] {
-                lowlink[node] = lowlink[node].min(index[next].expect("visited node has index"));
-            }
+    for start in 0..n {
+        if index[start].is_some() {
+            continue;
         }
 
-        if lowlink[node] == index[node].expect("visited node has index") {
-            let mut component = Vec::new();
-            while let Some(member) = stack.pop() {
-                on_stack[member] = false;
-                component.push(member);
-                if member == node {
-                    break;
+        index[start] = Some(next_index);
+        lowlink[start] = next_index;
+        next_index += 1;
+        scc_stack.push(start);
+        on_stack[start] = true;
+
+        let mut dfs_stack = vec![Frame {
+            node: start,
+            next_edge: 0,
+        }];
+
+        while !dfs_stack.is_empty() {
+            let frame_idx = dfs_stack.len() - 1;
+            let node = dfs_stack[frame_idx].node;
+
+            if dfs_stack[frame_idx].next_edge < adj[node].len() {
+                let next = adj[node][dfs_stack[frame_idx].next_edge];
+                dfs_stack[frame_idx].next_edge += 1;
+
+                if index[next].is_none() {
+                    index[next] = Some(next_index);
+                    lowlink[next] = next_index;
+                    next_index += 1;
+                    scc_stack.push(next);
+                    on_stack[next] = true;
+                    dfs_stack.push(Frame {
+                        node: next,
+                        next_edge: 0,
+                    });
+                } else if on_stack[next] {
+                    lowlink[node] = lowlink[node].min(index[next].expect("visited node has index"));
                 }
+                continue;
             }
-            component.sort_unstable();
-            components.push(component);
-        }
-    }
 
-    for node in 0..n {
-        if index[node].is_none() {
-            strong_connect(
-                node,
-                adj,
-                &mut next_index,
-                &mut index,
-                &mut lowlink,
-                &mut stack,
-                &mut on_stack,
-                &mut components,
-            );
+            dfs_stack.pop();
+
+            if lowlink[node] == index[node].expect("visited node has index") {
+                let mut component = Vec::new();
+                while let Some(member) = scc_stack.pop() {
+                    on_stack[member] = false;
+                    component.push(member);
+                    if member == node {
+                        break;
+                    }
+                }
+                component.sort_unstable();
+                components.push(component);
+            }
+
+            if let Some(parent) = dfs_stack.last() {
+                lowlink[parent.node] = lowlink[parent.node].min(lowlink[node]);
+            }
         }
     }
 
@@ -727,21 +738,24 @@ fn topologically_order_blocks(
         .collect();
 
     let mut ordered_blocks = Vec::with_capacity(blocks.len());
-    let mut ready: Vec<_> = (0..components.len())
-        .filter(|&component| indegree[component] == 0)
-        .collect();
-    ready.sort_by_key(|&component| equality_block_sort_key(&blocks[component]));
+    let mut ready = BinaryHeap::new();
+    for component in 0..components.len() {
+        if indegree[component] == 0 {
+            ready.push(Reverse((
+                equality_block_sort_key(&blocks[component]),
+                component,
+            )));
+        }
+    }
 
-    while !ready.is_empty() {
-        let component = ready.remove(0);
+    while let Some(Reverse((_key, component))) = ready.pop() {
         ordered_blocks.push(blocks[component].clone());
         for &next in &component_edges[component] {
             indegree[next] -= 1;
             if indegree[next] == 0 {
-                ready.push(next);
+                ready.push(Reverse((equality_block_sort_key(&blocks[next]), next)));
             }
         }
-        ready.sort_by_key(|&component| equality_block_sort_key(&blocks[component]));
     }
 
     ordered_blocks
@@ -1233,5 +1247,50 @@ mod tests {
                 unmatched_vars: vec![1],
             }
         );
+    }
+
+    #[test]
+    fn btd_handles_long_triangular_dependency_chain_iteratively() {
+        let chain_len = 10_000;
+        let bounds = equality_bounds(chain_len);
+        let mut edges = Vec::with_capacity(2 * chain_len - 1);
+        edges.push((0, 0));
+        for row in 1..chain_len {
+            edges.push((row, row - 1));
+            edges.push((row, row));
+        }
+        let problem = graph_problem(chain_len, &bounds, &edges);
+        let inc = EqualityIncidence::from_problem(&problem, TOL);
+
+        let selected: Vec<_> = (0..chain_len).collect();
+        let blocks = inc
+            .block_triangular_decomposition(&selected, &selected)
+            .unwrap();
+
+        assert_eq!(blocks.len(), chain_len);
+        for (idx, block) in blocks.iter().enumerate() {
+            assert_eq!(block.rows, vec![idx]);
+            assert_eq!(block.vars, vec![idx]);
+        }
+    }
+
+    #[test]
+    fn btd_handles_many_independent_blocks_with_heap_ready_set() {
+        let block_count = 10_000;
+        let bounds = equality_bounds(block_count);
+        let edges: Vec<_> = (0..block_count).map(|idx| (idx, idx)).collect();
+        let problem = graph_problem(block_count, &bounds, &edges);
+        let inc = EqualityIncidence::from_problem(&problem, TOL);
+
+        let selected: Vec<_> = (0..block_count).rev().collect();
+        let blocks = inc
+            .block_triangular_decomposition(&selected, &selected)
+            .unwrap();
+
+        assert_eq!(blocks.len(), block_count);
+        for (idx, block) in blocks.iter().enumerate() {
+            assert_eq!(block.rows, vec![idx]);
+            assert_eq!(block.vars, vec![idx]);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Add crate-private equality block output and BTD rejection errors for auxiliary preprocessing.
- Add selected-row/variable connected components over the equality incidence graph.
- Add deterministic block triangular decomposition for square, perfectly matched selections using projected row dependencies and Tarjan SCCs.
- Cover independent components, triangular ordering, cyclic blocks, and rejection cases.

## Tests run

- `cargo test auxiliary_preprocessing` - passed: 20 auxiliary preprocessing tests passed.
- `rustfmt --check src/auxiliary_preprocessing.rs` - passed.
- `git diff --check` - passed.
- `cargo nextest run` - passed: 311 tests passed, 25 skipped.
- `cargo test --doc` - passed: 1 doc test passed.
- `cargo build --release` - passed.
- `cc examples/c_api_test.c -I. -Ltarget/release -lripopt -Wl,-rpath,/home/bernalde/repos/ripopt/target/release -o target/release/c_api_test -lm` - passed.
- `target/release/c_api_test` - passed.
- `cc examples/c_rosenbrock.c -I. -Ltarget/release -lripopt -Wl,-rpath,/home/bernalde/repos/ripopt/target/release -o target/release/c_rosenbrock -lm` - passed.
- `target/release/c_rosenbrock` - passed.
- `cc examples/c_hs035.c -I. -Ltarget/release -lripopt -Wl,-rpath,/home/bernalde/repos/ripopt/target/release -o target/release/c_hs035 -lm` - passed.
- `target/release/c_hs035` - passed.
- `cc examples/c_example_with_options.c -I. -Ltarget/release -lripopt -Wl,-rpath,/home/bernalde/repos/ripopt/target/release -o target/release/c_example_with_options -lm` - passed.
- `target/release/c_example_with_options` - passed.
- `cargo test` - passed.

## Notes

- `cargo fmt --check` was not clean across the whole repo due to pre-existing formatting diffs in unrelated files, including generated benchmark sources. The touched file passes `rustfmt --check src/auxiliary_preprocessing.rs`.

Closes #3
