### PR TITLE
Implement auxiliary block preprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,7 @@ Key options (all have Ipopt-matching defaults):
 | `constr_viol_tol`               | 1e-4    | Constraint violation tolerance                             |
 | `dual_inf_tol`                  | 1.0     | Dual infeasibility tolerance                               |
 | `enable_preprocessing`          | true    | Eliminate fixed variables and redundant constraints        |
+| `auxiliary_tol`                 | 1e-8    | Accepted residual for auxiliary preprocessing block solves |
 | `detect_linear_constraints`     | true    | Skip Hessian for linear constraints                        |
 | `enable_sqp_fallback`           | true    | SQP fallback for constrained problems                      |
 | `hessian_approximation_lbfgs`   | false   | Use L-BFGS Hessian approximation (no exact Hessian needed) |
@@ -621,6 +622,7 @@ Option-setting functions return `1` on success, `0` if the keyword is unknown. A
 | `constr_viol_tol`            | 1e-4    | Constraint violation tolerance                  |
 | `dual_inf_tol`               | 1.0     | Dual infeasibility tolerance                    |
 | `compl_inf_tol`              | 1e-4    | Complementarity tolerance                       |
+| `auxiliary_tol`              | 1e-8    | Auxiliary preprocessing residual tolerance      |
 | `max_wall_time`              | 0.0     | Wall-clock time limit in seconds (0 = no limit) |
 | `warm_start_bound_push`      | 1e-3    | Warm-start bound push                           |
 | `warm_start_bound_frac`      | 1e-3    | Warm-start bound fraction                       |

--- a/docs/src/options.md
+++ b/docs/src/options.md
@@ -117,6 +117,7 @@ let opts = SolverOptions {
 | Option | Default | Description |
 |---|---|---|
 | `enable_preprocessing` | `true` | Eliminate fixed variables and redundant constraints |
+| `auxiliary_tol` | `1e-8` | Accepted residual for auxiliary preprocessing block solves |
 | `detect_linear_constraints` | `true` | Skip Hessian for constraints with zero second derivatives |
 | `proactive_infeasibility_detection` | `false` | Early infeasibility detection during iterations |
 

--- a/src/auxiliary_preprocessing.rs
+++ b/src/auxiliary_preprocessing.rs
@@ -9,6 +9,7 @@ use crate::problem::NlpProblem;
 use crate::result::{SolveResult, SolveStatus};
 use std::cmp::Reverse;
 use std::collections::{BinaryHeap, VecDeque};
+use std::time::Instant;
 
 #[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -40,6 +41,9 @@ pub(crate) enum AuxiliarySolveError {
     },
     EvaluationFailed {
         block: EqualityBlock,
+    },
+    TimeBudgetExceeded {
+        blocks_solved: usize,
     },
     BlockSolveFailed {
         block: EqualityBlock,
@@ -374,16 +378,18 @@ pub(crate) fn solve_auxiliary_blocks(
     problem: &dyn NlpProblem,
     candidates: &[PresolveCandidate],
     options: &SolverOptions,
+    solve_start: Instant,
 ) -> Result<AuxiliarySolveOutcome, AuxiliarySolveError> {
     let mut x_full = vec![0.0; problem.num_variables()];
     problem.initial_point(&mut x_full);
-    solve_auxiliary_blocks_from(problem, candidates, options, &mut x_full)
+    solve_auxiliary_blocks_from(problem, candidates, options, solve_start, &mut x_full)
 }
 
 pub(crate) fn solve_auxiliary_blocks_from(
     problem: &dyn NlpProblem,
     candidates: &[PresolveCandidate],
     options: &SolverOptions,
+    solve_start: Instant,
     x_full: &mut [f64],
 ) -> Result<AuxiliarySolveOutcome, AuxiliarySolveError> {
     let mut blocks_solved = 0;
@@ -392,7 +398,9 @@ pub(crate) fn solve_auxiliary_blocks_from(
     for candidate in candidates {
         for block in &candidate.blocks {
             let block_problem = AuxiliaryBlockProblem::new(problem, block, x_full)?;
-            let aux_options = auxiliary_solver_options(options);
+            let Some(aux_options) = auxiliary_solver_options(options, solve_start) else {
+                return Err(AuxiliarySolveError::TimeBudgetExceeded { blocks_solved });
+            };
             let result = crate::solve(&block_problem, &aux_options);
             let residual = auxiliary_result_residual(&block_problem, &result)?;
 
@@ -474,7 +482,10 @@ fn has_duplicates(values: &[usize]) -> bool {
     values.windows(2).any(|pair| pair[0] == pair[1])
 }
 
-fn auxiliary_solver_options(options: &SolverOptions) -> SolverOptions {
+fn auxiliary_solver_options(
+    options: &SolverOptions,
+    solve_start: Instant,
+) -> Option<SolverOptions> {
     let mut aux_options = options.clone();
     aux_options.enable_preprocessing = false;
     aux_options.warm_start = false;
@@ -484,7 +495,14 @@ fn auxiliary_solver_options(options: &SolverOptions) -> SolverOptions {
     aux_options.user_obj_scaling = None;
     aux_options.user_g_scaling = None;
     aux_options.user_x_scaling = None;
-    aux_options
+    if options.max_wall_time > 0.0 {
+        let remaining = options.max_wall_time - solve_start.elapsed().as_secs_f64();
+        if remaining <= 0.0 {
+            return None;
+        }
+        aux_options.max_wall_time = remaining;
+    }
+    Some(aux_options)
 }
 
 fn auxiliary_result_residual(
@@ -1607,7 +1625,8 @@ mod tests {
         let options = quiet_aux_options();
 
         let outcome =
-            solve_auxiliary_blocks(&problem, &candidates, &options).expect("auxiliary solve");
+            solve_auxiliary_blocks(&problem, &candidates, &options, std::time::Instant::now())
+                .expect("auxiliary solve");
 
         assert_eq!(outcome.blocks_solved, 1);
         assert!(outcome.max_residual <= options.auxiliary_tol);
@@ -1622,7 +1641,8 @@ mod tests {
         let options = quiet_aux_options();
 
         let outcome =
-            solve_auxiliary_blocks(&problem, &candidates, &options).expect("auxiliary solve");
+            solve_auxiliary_blocks(&problem, &candidates, &options, std::time::Instant::now())
+                .expect("auxiliary solve");
 
         assert_eq!(outcome.blocks_solved, 2);
         assert!(outcome.max_residual <= options.auxiliary_tol);
@@ -1636,7 +1656,9 @@ mod tests {
         let candidates = find_presolve_candidates(&problem, TOL);
         let options = quiet_aux_options();
 
-        let err = solve_auxiliary_blocks(&problem, &candidates, &options).unwrap_err();
+        let err =
+            solve_auxiliary_blocks(&problem, &candidates, &options, std::time::Instant::now())
+                .unwrap_err();
 
         match err {
             AuxiliarySolveError::BlockSolveFailed {
@@ -1650,6 +1672,23 @@ mod tests {
             }
             other => panic!("unexpected auxiliary error: {:?}", other),
         }
+    }
+
+    #[test]
+    fn auxiliary_solve_stops_when_outer_wall_time_is_exhausted() {
+        let problem = TriangularAuxProblem;
+        let candidates = find_presolve_candidates(&problem, TOL);
+        let mut options = quiet_aux_options();
+        options.max_wall_time = 0.01;
+        let expired_start = std::time::Instant::now() - std::time::Duration::from_secs(1);
+
+        let err =
+            solve_auxiliary_blocks(&problem, &candidates, &options, expired_start).unwrap_err();
+
+        assert_eq!(
+            err,
+            AuxiliarySolveError::TimeBudgetExceeded { blocks_solved: 0 }
+        );
     }
 
     #[test]

--- a/src/auxiliary_preprocessing.rs
+++ b/src/auxiliary_preprocessing.rs
@@ -4,7 +4,9 @@
 //! implementation detail of `enable_preprocessing`; it must not expose a public
 //! decomposition or transform API.
 
+use crate::options::SolverOptions;
 use crate::problem::NlpProblem;
+use crate::result::{SolveResult, SolveStatus};
 use std::cmp::Reverse;
 use std::collections::{BinaryHeap, VecDeque};
 
@@ -19,6 +21,31 @@ pub(crate) struct EqualityBlock {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct PresolveCandidate {
     pub(crate) blocks: Vec<EqualityBlock>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct AuxiliarySolveOutcome {
+    pub(crate) x: Vec<f64>,
+    pub(crate) blocks_solved: usize,
+    pub(crate) max_residual: f64,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum AuxiliarySolveError {
+    InvalidBlock {
+        block: EqualityBlock,
+        reason: &'static str,
+    },
+    EvaluationFailed {
+        block: EqualityBlock,
+    },
+    BlockSolveFailed {
+        block: EqualityBlock,
+        status: SolveStatus,
+        residual: f64,
+    },
 }
 
 #[allow(dead_code)]
@@ -43,6 +70,466 @@ pub(crate) struct EqualityIncidence {
     pub(crate) row_local_for_global: Vec<Option<usize>>,
     pub(crate) row_adj_vars: Vec<Vec<usize>>,
     pub(crate) var_adj_rows: Vec<Vec<usize>>,
+}
+
+#[allow(dead_code)]
+pub(crate) struct AuxiliaryBlockProblem<'a> {
+    inner: &'a dyn NlpProblem,
+    n_orig: usize,
+    m_orig: usize,
+    rows: Vec<usize>,
+    vars: Vec<usize>,
+    fixed_x: Vec<f64>,
+    jac_rows: Vec<usize>,
+    jac_cols: Vec<usize>,
+    jac_entry_map: Vec<usize>,
+    inner_jac_nnz: usize,
+    hess_rows: Vec<usize>,
+    hess_cols: Vec<usize>,
+    hess_entry_map: Vec<usize>,
+    inner_hess_nnz: usize,
+}
+
+impl<'a> AuxiliaryBlockProblem<'a> {
+    pub(crate) fn new(
+        inner: &'a dyn NlpProblem,
+        block: &EqualityBlock,
+        fixed_x: &[f64],
+    ) -> Result<Self, AuxiliarySolveError> {
+        let n_orig = inner.num_variables();
+        let m_orig = inner.num_constraints();
+        validate_auxiliary_block(block, fixed_x, n_orig, m_orig)?;
+
+        let mut row_local_for_global = vec![None; m_orig];
+        for (local, &row) in block.rows.iter().enumerate() {
+            row_local_for_global[row] = Some(local);
+        }
+        let mut var_local_for_global = vec![None; n_orig];
+        for (local, &var) in block.vars.iter().enumerate() {
+            var_local_for_global[var] = Some(local);
+        }
+
+        let (inner_jac_rows, inner_jac_cols) = inner.jacobian_structure();
+        let mut jac_rows = Vec::new();
+        let mut jac_cols = Vec::new();
+        let mut jac_entry_map = Vec::new();
+        for (idx, (&row, &col)) in inner_jac_rows.iter().zip(inner_jac_cols.iter()).enumerate() {
+            if row >= m_orig || col >= n_orig {
+                continue;
+            }
+            if let (Some(local_row), Some(local_col)) =
+                (row_local_for_global[row], var_local_for_global[col])
+            {
+                jac_rows.push(local_row);
+                jac_cols.push(local_col);
+                jac_entry_map.push(idx);
+            }
+        }
+
+        let (inner_hess_rows, inner_hess_cols) = inner.hessian_structure();
+        let mut hess_rows = Vec::new();
+        let mut hess_cols = Vec::new();
+        let mut hess_entry_map = Vec::new();
+        for (idx, (&row, &col)) in inner_hess_rows
+            .iter()
+            .zip(inner_hess_cols.iter())
+            .enumerate()
+        {
+            if row >= n_orig || col >= n_orig {
+                continue;
+            }
+            if let (Some(local_row), Some(local_col)) =
+                (var_local_for_global[row], var_local_for_global[col])
+            {
+                if local_row >= local_col {
+                    hess_rows.push(local_row);
+                    hess_cols.push(local_col);
+                } else {
+                    hess_rows.push(local_col);
+                    hess_cols.push(local_row);
+                }
+                hess_entry_map.push(idx);
+            }
+        }
+
+        Ok(Self {
+            inner,
+            n_orig,
+            m_orig,
+            rows: block.rows.clone(),
+            vars: block.vars.clone(),
+            fixed_x: fixed_x.to_vec(),
+            jac_rows,
+            jac_cols,
+            jac_entry_map,
+            inner_jac_nnz: inner_jac_rows.len(),
+            hess_rows,
+            hess_cols,
+            hess_entry_map,
+            inner_hess_nnz: inner_hess_rows.len(),
+        })
+    }
+
+    fn block(&self) -> EqualityBlock {
+        EqualityBlock {
+            rows: self.rows.clone(),
+            vars: self.vars.clone(),
+        }
+    }
+
+    fn expand_x(&self, x_block: &[f64]) -> Vec<f64> {
+        let mut x_full = self.fixed_x.clone();
+        for (local, &var) in self.vars.iter().enumerate() {
+            x_full[var] = x_block[local];
+        }
+        x_full
+    }
+}
+
+impl NlpProblem for AuxiliaryBlockProblem<'_> {
+    fn num_variables(&self) -> usize {
+        self.vars.len()
+    }
+
+    fn num_constraints(&self) -> usize {
+        self.rows.len()
+    }
+
+    fn bounds(&self, x_l: &mut [f64], x_u: &mut [f64]) {
+        let mut x_l_full = vec![0.0; self.n_orig];
+        let mut x_u_full = vec![0.0; self.n_orig];
+        self.inner.bounds(&mut x_l_full, &mut x_u_full);
+        for (local, &var) in self.vars.iter().enumerate() {
+            x_l[local] = x_l_full[var];
+            x_u[local] = x_u_full[var];
+        }
+    }
+
+    fn constraint_bounds(&self, g_l: &mut [f64], g_u: &mut [f64]) {
+        let mut g_l_full = vec![0.0; self.m_orig];
+        let mut g_u_full = vec![0.0; self.m_orig];
+        self.inner.constraint_bounds(&mut g_l_full, &mut g_u_full);
+        for (local, &row) in self.rows.iter().enumerate() {
+            g_l[local] = g_l_full[row];
+            g_u[local] = g_u_full[row];
+        }
+    }
+
+    fn initial_point(&self, x0: &mut [f64]) {
+        for (local, &var) in self.vars.iter().enumerate() {
+            x0[local] = self.fixed_x[var];
+        }
+    }
+
+    fn objective(&self, _x: &[f64], _new_x: bool, obj: &mut f64) -> bool {
+        *obj = 0.0;
+        true
+    }
+
+    fn gradient(&self, _x: &[f64], _new_x: bool, grad: &mut [f64]) -> bool {
+        grad.fill(0.0);
+        true
+    }
+
+    fn constraints(&self, x: &[f64], new_x: bool, g: &mut [f64]) -> bool {
+        let x_full = self.expand_x(x);
+        let mut g_full = vec![0.0; self.m_orig];
+        if !self.inner.constraints(&x_full, new_x, &mut g_full) {
+            return false;
+        }
+        for (local, &row) in self.rows.iter().enumerate() {
+            g[local] = g_full[row];
+        }
+        true
+    }
+
+    fn jacobian_structure(&self) -> (Vec<usize>, Vec<usize>) {
+        (self.jac_rows.clone(), self.jac_cols.clone())
+    }
+
+    fn jacobian_values(&self, x: &[f64], new_x: bool, vals: &mut [f64]) -> bool {
+        if self.jac_entry_map.is_empty() {
+            return true;
+        }
+        let x_full = self.expand_x(x);
+        let mut inner_vals = vec![0.0; self.inner_jac_nnz];
+        if !self.inner.jacobian_values(&x_full, new_x, &mut inner_vals) {
+            return false;
+        }
+        for (local, &inner_idx) in self.jac_entry_map.iter().enumerate() {
+            vals[local] = inner_vals[inner_idx];
+        }
+        true
+    }
+
+    fn hessian_structure(&self) -> (Vec<usize>, Vec<usize>) {
+        (self.hess_rows.clone(), self.hess_cols.clone())
+    }
+
+    fn hessian_values(
+        &self,
+        x: &[f64],
+        new_x: bool,
+        _obj_factor: f64,
+        lambda: &[f64],
+        vals: &mut [f64],
+    ) -> bool {
+        if self.hess_entry_map.is_empty() {
+            return true;
+        }
+        let x_full = self.expand_x(x);
+        let mut lambda_full = vec![0.0; self.m_orig];
+        for (local, &row) in self.rows.iter().enumerate() {
+            lambda_full[row] = lambda[local];
+        }
+
+        let mut inner_vals = vec![0.0; self.inner_hess_nnz];
+        if !self
+            .inner
+            .hessian_values(&x_full, new_x, 0.0, &lambda_full, &mut inner_vals)
+        {
+            return false;
+        }
+        for (local, &inner_idx) in self.hess_entry_map.iter().enumerate() {
+            vals[local] = inner_vals[inner_idx];
+        }
+        true
+    }
+}
+
+pub(crate) struct SeededInitialPointProblem<'a> {
+    inner: &'a dyn NlpProblem,
+    x0: Vec<f64>,
+}
+
+impl<'a> SeededInitialPointProblem<'a> {
+    pub(crate) fn new(inner: &'a dyn NlpProblem, x0: Vec<f64>) -> Self {
+        Self { inner, x0 }
+    }
+}
+
+impl NlpProblem for SeededInitialPointProblem<'_> {
+    fn num_variables(&self) -> usize {
+        self.inner.num_variables()
+    }
+
+    fn num_constraints(&self) -> usize {
+        self.inner.num_constraints()
+    }
+
+    fn bounds(&self, x_l: &mut [f64], x_u: &mut [f64]) {
+        self.inner.bounds(x_l, x_u);
+    }
+
+    fn constraint_bounds(&self, g_l: &mut [f64], g_u: &mut [f64]) {
+        self.inner.constraint_bounds(g_l, g_u);
+    }
+
+    fn initial_point(&self, x0: &mut [f64]) {
+        x0.copy_from_slice(&self.x0);
+    }
+
+    fn initial_multipliers(&self, lam_g: &mut [f64], z_l: &mut [f64], z_u: &mut [f64]) -> bool {
+        self.inner.initial_multipliers(lam_g, z_l, z_u)
+    }
+
+    fn objective(&self, x: &[f64], new_x: bool, obj: &mut f64) -> bool {
+        self.inner.objective(x, new_x, obj)
+    }
+
+    fn gradient(&self, x: &[f64], new_x: bool, grad: &mut [f64]) -> bool {
+        self.inner.gradient(x, new_x, grad)
+    }
+
+    fn constraints(&self, x: &[f64], new_x: bool, g: &mut [f64]) -> bool {
+        self.inner.constraints(x, new_x, g)
+    }
+
+    fn jacobian_structure(&self) -> (Vec<usize>, Vec<usize>) {
+        self.inner.jacobian_structure()
+    }
+
+    fn jacobian_values(&self, x: &[f64], new_x: bool, vals: &mut [f64]) -> bool {
+        self.inner.jacobian_values(x, new_x, vals)
+    }
+
+    fn hessian_structure(&self) -> (Vec<usize>, Vec<usize>) {
+        self.inner.hessian_structure()
+    }
+
+    fn hessian_values(
+        &self,
+        x: &[f64],
+        new_x: bool,
+        obj_factor: f64,
+        lambda: &[f64],
+        vals: &mut [f64],
+    ) -> bool {
+        self.inner
+            .hessian_values(x, new_x, obj_factor, lambda, vals)
+    }
+}
+
+pub(crate) fn solve_auxiliary_blocks(
+    problem: &dyn NlpProblem,
+    candidates: &[PresolveCandidate],
+    options: &SolverOptions,
+) -> Result<AuxiliarySolveOutcome, AuxiliarySolveError> {
+    let mut x_full = vec![0.0; problem.num_variables()];
+    problem.initial_point(&mut x_full);
+    solve_auxiliary_blocks_from(problem, candidates, options, &mut x_full)
+}
+
+pub(crate) fn solve_auxiliary_blocks_from(
+    problem: &dyn NlpProblem,
+    candidates: &[PresolveCandidate],
+    options: &SolverOptions,
+    x_full: &mut [f64],
+) -> Result<AuxiliarySolveOutcome, AuxiliarySolveError> {
+    let mut blocks_solved = 0;
+    let mut max_residual: f64 = 0.0;
+
+    for candidate in candidates {
+        for block in &candidate.blocks {
+            let block_problem = AuxiliaryBlockProblem::new(problem, block, x_full)?;
+            let aux_options = auxiliary_solver_options(options);
+            let result = crate::solve(&block_problem, &aux_options);
+            let residual = auxiliary_result_residual(&block_problem, &result)?;
+
+            if !(matches!(
+                result.status,
+                SolveStatus::Optimal | SolveStatus::Acceptable
+            ) && residual <= options.auxiliary_tol)
+            {
+                return Err(AuxiliarySolveError::BlockSolveFailed {
+                    block: block_problem.block(),
+                    status: result.status,
+                    residual,
+                });
+            }
+
+            for (local, &var) in block.vars.iter().enumerate() {
+                x_full[var] = result.x[local];
+            }
+            blocks_solved += 1;
+            max_residual = max_residual.max(residual);
+        }
+    }
+
+    Ok(AuxiliarySolveOutcome {
+        x: x_full.to_vec(),
+        blocks_solved,
+        max_residual,
+    })
+}
+
+fn validate_auxiliary_block(
+    block: &EqualityBlock,
+    fixed_x: &[f64],
+    n_orig: usize,
+    m_orig: usize,
+) -> Result<(), AuxiliarySolveError> {
+    if fixed_x.len() != n_orig {
+        return Err(AuxiliarySolveError::InvalidBlock {
+            block: block.clone(),
+            reason: "fixed_x length does not match problem variables",
+        });
+    }
+    if block.rows.is_empty() || block.vars.is_empty() {
+        return Err(AuxiliarySolveError::InvalidBlock {
+            block: block.clone(),
+            reason: "block must contain at least one row and one variable",
+        });
+    }
+    if block.rows.iter().any(|&row| row >= m_orig) {
+        return Err(AuxiliarySolveError::InvalidBlock {
+            block: block.clone(),
+            reason: "block row is out of range",
+        });
+    }
+    if block.vars.iter().any(|&var| var >= n_orig) {
+        return Err(AuxiliarySolveError::InvalidBlock {
+            block: block.clone(),
+            reason: "block variable is out of range",
+        });
+    }
+    if has_duplicates(&block.rows) {
+        return Err(AuxiliarySolveError::InvalidBlock {
+            block: block.clone(),
+            reason: "block rows must be unique",
+        });
+    }
+    if has_duplicates(&block.vars) {
+        return Err(AuxiliarySolveError::InvalidBlock {
+            block: block.clone(),
+            reason: "block variables must be unique",
+        });
+    }
+    Ok(())
+}
+
+fn has_duplicates(values: &[usize]) -> bool {
+    let mut values = values.to_vec();
+    values.sort_unstable();
+    values.windows(2).any(|pair| pair[0] == pair[1])
+}
+
+fn auxiliary_solver_options(options: &SolverOptions) -> SolverOptions {
+    let mut aux_options = options.clone();
+    aux_options.enable_preprocessing = false;
+    aux_options.warm_start = false;
+    aux_options.warm_start_y = None;
+    aux_options.warm_start_z_l = None;
+    aux_options.warm_start_z_u = None;
+    aux_options.user_obj_scaling = None;
+    aux_options.user_g_scaling = None;
+    aux_options.user_x_scaling = None;
+    aux_options
+}
+
+fn auxiliary_result_residual(
+    problem: &AuxiliaryBlockProblem<'_>,
+    result: &SolveResult,
+) -> Result<f64, AuxiliarySolveError> {
+    let m = problem.num_constraints();
+    let g = if result.constraint_values.len() == m {
+        result.constraint_values.clone()
+    } else {
+        let mut values = vec![0.0; m];
+        if !problem.constraints(&result.x, true, &mut values) {
+            return Err(AuxiliarySolveError::EvaluationFailed {
+                block: problem.block(),
+            });
+        }
+        values
+    };
+
+    let mut g_l = vec![0.0; m];
+    let mut g_u = vec![0.0; m];
+    problem.constraint_bounds(&mut g_l, &mut g_u);
+
+    let mut residual: f64 = 0.0;
+    for i in 0..m {
+        let violation = if !g[i].is_finite() {
+            f64::INFINITY
+        } else if g_l[i].is_finite() && g_u[i].is_finite() && (g_u[i] - g_l[i]).abs() <= 1e-12 {
+            (g[i] - 0.5 * (g_l[i] + g_u[i])).abs()
+        } else {
+            let lower = if g_l[i].is_finite() {
+                (g_l[i] - g[i]).max(0.0)
+            } else {
+                0.0
+            };
+            let upper = if g_u[i].is_finite() {
+                (g[i] - g_u[i]).max(0.0)
+            } else {
+                0.0
+            };
+            lower.max(upper)
+        };
+        residual = residual.max(violation);
+    }
+    Ok(residual)
 }
 
 #[allow(dead_code)]
@@ -958,6 +1445,235 @@ mod tests {
 
     fn equality_bounds(n_rows: usize) -> Vec<(f64, f64)> {
         vec![(0.0, 0.0); n_rows]
+    }
+
+    fn quiet_aux_options() -> SolverOptions {
+        let mut options = SolverOptions::default();
+        options.print_level = 0;
+        options.max_iter = 200;
+        options.auxiliary_tol = 1e-7;
+        options
+    }
+
+    struct TriangularAuxProblem;
+
+    impl NlpProblem for TriangularAuxProblem {
+        fn num_variables(&self) -> usize {
+            2
+        }
+
+        fn num_constraints(&self) -> usize {
+            2
+        }
+
+        fn bounds(&self, x_l: &mut [f64], x_u: &mut [f64]) {
+            x_l[0] = 0.1;
+            x_u[0] = 10.0;
+            x_l[1] = 0.0;
+            x_u[1] = 10.0;
+        }
+
+        fn constraint_bounds(&self, g_l: &mut [f64], g_u: &mut [f64]) {
+            g_l[0] = 4.0;
+            g_u[0] = 4.0;
+            g_l[1] = 0.0;
+            g_u[1] = 0.0;
+        }
+
+        fn initial_point(&self, x0: &mut [f64]) {
+            x0[0] = 1.0;
+            x0[1] = 0.0;
+        }
+
+        fn objective(&self, x: &[f64], _new_x: bool, obj: &mut f64) -> bool {
+            *obj = x[0] + x[1];
+            true
+        }
+
+        fn gradient(&self, _x: &[f64], _new_x: bool, grad: &mut [f64]) -> bool {
+            grad[0] = 1.0;
+            grad[1] = 1.0;
+            true
+        }
+
+        fn constraints(&self, x: &[f64], _new_x: bool, g: &mut [f64]) -> bool {
+            g[0] = x[0] * x[0];
+            g[1] = x[1] - x[0] - 1.0;
+            true
+        }
+
+        fn jacobian_structure(&self) -> (Vec<usize>, Vec<usize>) {
+            (vec![0, 1, 1], vec![0, 0, 1])
+        }
+
+        fn jacobian_values(&self, x: &[f64], _new_x: bool, vals: &mut [f64]) -> bool {
+            vals[0] = 2.0 * x[0];
+            vals[1] = -1.0;
+            vals[2] = 1.0;
+            true
+        }
+
+        fn hessian_structure(&self) -> (Vec<usize>, Vec<usize>) {
+            (vec![0], vec![0])
+        }
+
+        fn hessian_values(
+            &self,
+            _x: &[f64],
+            _new_x: bool,
+            _obj_factor: f64,
+            lambda: &[f64],
+            vals: &mut [f64],
+        ) -> bool {
+            vals[0] = 2.0 * lambda[0];
+            true
+        }
+    }
+
+    struct InfeasibleBoundAuxProblem;
+
+    impl NlpProblem for InfeasibleBoundAuxProblem {
+        fn num_variables(&self) -> usize {
+            1
+        }
+
+        fn num_constraints(&self) -> usize {
+            1
+        }
+
+        fn bounds(&self, x_l: &mut [f64], x_u: &mut [f64]) {
+            x_l[0] = 0.0;
+            x_u[0] = 1.0;
+        }
+
+        fn constraint_bounds(&self, g_l: &mut [f64], g_u: &mut [f64]) {
+            g_l[0] = 2.0;
+            g_u[0] = 2.0;
+        }
+
+        fn initial_point(&self, x0: &mut [f64]) {
+            x0[0] = 0.5;
+        }
+
+        fn objective(&self, _x: &[f64], _new_x: bool, obj: &mut f64) -> bool {
+            *obj = 0.0;
+            true
+        }
+
+        fn gradient(&self, _x: &[f64], _new_x: bool, grad: &mut [f64]) -> bool {
+            grad[0] = 0.0;
+            true
+        }
+
+        fn constraints(&self, x: &[f64], _new_x: bool, g: &mut [f64]) -> bool {
+            g[0] = x[0];
+            true
+        }
+
+        fn jacobian_structure(&self) -> (Vec<usize>, Vec<usize>) {
+            (vec![0], vec![0])
+        }
+
+        fn jacobian_values(&self, _x: &[f64], _new_x: bool, vals: &mut [f64]) -> bool {
+            vals[0] = 1.0;
+            true
+        }
+
+        fn hessian_structure(&self) -> (Vec<usize>, Vec<usize>) {
+            (vec![], vec![])
+        }
+
+        fn hessian_values(
+            &self,
+            _x: &[f64],
+            _new_x: bool,
+            _obj_factor: f64,
+            _lambda: &[f64],
+            _vals: &mut [f64],
+        ) -> bool {
+            true
+        }
+    }
+
+    #[test]
+    fn auxiliary_solve_handles_one_variable_nonlinear_equality() {
+        let problem = TriangularAuxProblem;
+        let candidates = vec![PresolveCandidate {
+            blocks: vec![EqualityBlock {
+                rows: vec![0],
+                vars: vec![0],
+            }],
+        }];
+        let options = quiet_aux_options();
+
+        let outcome =
+            solve_auxiliary_blocks(&problem, &candidates, &options).expect("auxiliary solve");
+
+        assert_eq!(outcome.blocks_solved, 1);
+        assert!(outcome.max_residual <= options.auxiliary_tol);
+        assert!((outcome.x[0] - 2.0).abs() < 1e-5, "x = {:?}", outcome.x);
+        assert_eq!(outcome.x[1], 0.0);
+    }
+
+    #[test]
+    fn auxiliary_solve_updates_full_vector_between_triangular_blocks() {
+        let problem = TriangularAuxProblem;
+        let candidates = find_presolve_candidates(&problem, TOL);
+        let options = quiet_aux_options();
+
+        let outcome =
+            solve_auxiliary_blocks(&problem, &candidates, &options).expect("auxiliary solve");
+
+        assert_eq!(outcome.blocks_solved, 2);
+        assert!(outcome.max_residual <= options.auxiliary_tol);
+        assert!((outcome.x[0] - 2.0).abs() < 1e-5, "x = {:?}", outcome.x);
+        assert!((outcome.x[1] - 3.0).abs() < 1e-5, "x = {:?}", outcome.x);
+    }
+
+    #[test]
+    fn auxiliary_solve_failure_returns_structured_failure() {
+        let problem = InfeasibleBoundAuxProblem;
+        let candidates = find_presolve_candidates(&problem, TOL);
+        let options = quiet_aux_options();
+
+        let err = solve_auxiliary_blocks(&problem, &candidates, &options).unwrap_err();
+
+        match err {
+            AuxiliarySolveError::BlockSolveFailed {
+                block,
+                status: _,
+                residual,
+            } => {
+                assert_eq!(block.rows, vec![0]);
+                assert_eq!(block.vars, vec![0]);
+                assert!(residual > options.auxiliary_tol || !residual.is_finite());
+            }
+            other => panic!("unexpected auxiliary error: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn auxiliary_block_problem_respects_original_variable_bounds() {
+        let problem = InfeasibleBoundAuxProblem;
+        let block = EqualityBlock {
+            rows: vec![0],
+            vars: vec![0],
+        };
+        let fixed_x = vec![0.5];
+        let aux = AuxiliaryBlockProblem::new(&problem, &block, &fixed_x).unwrap();
+
+        let mut x_l = vec![0.0; 1];
+        let mut x_u = vec![0.0; 1];
+        aux.bounds(&mut x_l, &mut x_u);
+        assert_eq!(x_l, vec![0.0]);
+        assert_eq!(x_u, vec![1.0]);
+
+        let result = crate::solve(&aux, &quiet_aux_options());
+        assert!(
+            result.x[0] >= -1e-10 && result.x[0] <= 1.0 + 1e-10,
+            "auxiliary solution violated bounds: {:?}",
+            result.x
+        );
     }
 
     #[test]

--- a/src/bin/ripopt_ampl.rs
+++ b/src/bin/ripopt_ampl.rs
@@ -140,6 +140,7 @@ fn print_help() {
     println!("    constr_viol_tol=<float>              Constraint violation tolerance [1e-4]");
     println!("    dual_inf_tol=<float>                 Dual infeasibility tolerance [1.0]");
     println!("    compl_inf_tol=<float>                Complementarity tolerance [1e-4]");
+    println!("    auxiliary_tol=<float>                Auxiliary preprocessing residual tolerance [1e-8]");
     println!();
     println!("  Barrier Parameter");
     println!("    mu_init=<float>                      Initial barrier parameter [0.1]");
@@ -268,6 +269,11 @@ fn apply_option(opts: &mut SolverOptions, key: &str, value: &str) {
         "compl_inf_tol" => {
             if let Ok(v) = value.parse() {
                 opts.compl_inf_tol = v;
+            }
+        }
+        "auxiliary_tol" => {
+            if let Ok(v) = value.parse() {
+                opts.auxiliary_tol = v;
             }
         }
         "kappa" => {

--- a/src/c_api.rs
+++ b/src/c_api.rs
@@ -459,6 +459,7 @@ pub unsafe extern "C" fn ripopt_add_num_option(
         "constr_viol_tol" => p.options.constr_viol_tol = val,
         "dual_inf_tol" => p.options.dual_inf_tol = val,
         "compl_inf_tol" => p.options.compl_inf_tol = val,
+        "auxiliary_tol" => p.options.auxiliary_tol = val,
         "warm_start_bound_push" => p.options.warm_start_bound_push = val,
         "warm_start_bound_frac" => p.options.warm_start_bound_frac = val,
         "warm_start_mult_bound_push" => p.options.warm_start_mult_bound_push = val,

--- a/src/ipm.rs
+++ b/src/ipm.rs
@@ -1631,6 +1631,73 @@ fn try_slow_optimal_slack_fallback<P: NlpProblem>(
     try_slack_fallback(result, problem, options, solve_start, diagnosis, has_inequalities)
 }
 
+/// Auxiliary preprocessing attempt: solve block-triangular equality
+/// subsystems first, use the solved full-space point as the initial point,
+/// then run a non-preprocessing recursive solve. If either the auxiliary
+/// blocks or the seeded solve fail, fall back to the normal solve path.
+fn try_auxiliary_preprocessed_solve<P: NlpProblem>(
+    problem: &P,
+    options: &SolverOptions,
+    solve_start: Instant,
+) -> Option<SolveResult> {
+    if !options.enable_preprocessing {
+        return None;
+    }
+
+    let problem_dyn = problem as &dyn NlpProblem;
+    let candidates =
+        crate::auxiliary_preprocessing::find_presolve_candidates(problem_dyn, options.auxiliary_tol);
+    if candidates.is_empty() {
+        return None;
+    }
+
+    let outcome =
+        match crate::auxiliary_preprocessing::solve_auxiliary_blocks(problem_dyn, &candidates, options)
+        {
+            Ok(outcome) if outcome.blocks_solved > 0 => outcome,
+            Ok(_) => return None,
+            Err(err) => {
+                if options.print_level >= 5 {
+                    rip_log!("ripopt: Auxiliary preprocessing skipped after failure: {:?}", err);
+                }
+                return None;
+            }
+        };
+
+    if options.print_level >= 5 {
+        rip_log!(
+            "ripopt: Auxiliary preprocessing solved {} block(s), max residual {:.2e}",
+            outcome.blocks_solved,
+            outcome.max_residual,
+        );
+    }
+
+    let seeded = crate::auxiliary_preprocessing::SeededInitialPointProblem::new(problem_dyn, outcome.x);
+    let mut seeded_opts = options.clone();
+    seeded_opts.enable_preprocessing = false;
+    if options.max_wall_time > 0.0 {
+        let remaining = options.max_wall_time - solve_start.elapsed().as_secs_f64();
+        if remaining <= 0.1 {
+            return None;
+        }
+        seeded_opts.max_wall_time = remaining * 0.5;
+    }
+
+    let mut result = solve(&seeded, &seeded_opts);
+    if matches!(result.status, SolveStatus::Optimal) {
+        result.diagnostics.fallback_used = Some("auxiliary_preprocessing".into());
+        return Some(result);
+    }
+
+    if options.print_level >= 5 {
+        rip_log!(
+            "ripopt: Auxiliary-seeded solve failed ({:?}), retrying without auxiliary preprocessing",
+            result.status,
+        );
+    }
+    None
+}
+
 /// Run preprocessing (fixed-variable and redundant-constraint elimination)
 /// and, if it reduces the problem, recursively `solve` the smaller problem
 /// then unmap the solution. Returns `Some(result)` only when the
@@ -1647,6 +1714,9 @@ fn try_preprocessed_solve<P: NlpProblem>(
 ) -> Option<SolveResult> {
     if !options.enable_preprocessing {
         return None;
+    }
+    if let Some(result) = try_auxiliary_preprocessed_solve(problem, options, solve_start) {
+        return Some(result);
     }
     let prep = crate::preprocessing::PreprocessedProblem::new(problem as &dyn NlpProblem, options.bound_push);
     if !prep.did_reduce() {

--- a/src/ipm.rs
+++ b/src/ipm.rs
@@ -1633,8 +1633,8 @@ fn try_slow_optimal_slack_fallback<P: NlpProblem>(
 
 /// Auxiliary preprocessing attempt: solve block-triangular equality
 /// subsystems first, use the solved full-space point as the initial point,
-/// then run a non-preprocessing recursive solve. If either the auxiliary
-/// blocks or the seeded solve fail, fall back to the normal solve path.
+/// then run a non-preprocessing recursive solve. The caller decides whether
+/// the seeded result improves on the normal solve.
 fn try_auxiliary_preprocessed_solve<P: NlpProblem>(
     problem: &P,
     options: &SolverOptions,
@@ -1652,7 +1652,7 @@ fn try_auxiliary_preprocessed_solve<P: NlpProblem>(
     }
 
     let outcome =
-        match crate::auxiliary_preprocessing::solve_auxiliary_blocks(problem_dyn, &candidates, options)
+        match crate::auxiliary_preprocessing::solve_auxiliary_blocks(problem_dyn, &candidates, options, solve_start)
         {
             Ok(outcome) if outcome.blocks_solved > 0 => outcome,
             Ok(_) => return None,
@@ -1683,9 +1683,8 @@ fn try_auxiliary_preprocessed_solve<P: NlpProblem>(
         seeded_opts.max_wall_time = remaining * 0.5;
     }
 
-    let mut result = solve(&seeded, &seeded_opts);
+    let result = solve(&seeded, &seeded_opts);
     if matches!(result.status, SolveStatus::Optimal) {
-        result.diagnostics.fallback_used = Some("auxiliary_preprocessing".into());
         return Some(result);
     }
 
@@ -1714,9 +1713,6 @@ fn try_preprocessed_solve<P: NlpProblem>(
 ) -> Option<SolveResult> {
     if !options.enable_preprocessing {
         return None;
-    }
-    if let Some(result) = try_auxiliary_preprocessed_solve(problem, options, solve_start) {
-        return Some(result);
     }
     let prep = crate::preprocessing::PreprocessedProblem::new(problem as &dyn NlpProblem, options.bound_push);
     if !prep.did_reduce() {
@@ -2218,6 +2214,18 @@ fn solve_inner<P: NlpProblem>(
     }
 
     try_conservative_ipm_retry(&mut result, problem, options, solve_start);
+
+    if !matches!(result.status, SolveStatus::Optimal) {
+        if let Some(candidate) = try_auxiliary_preprocessed_solve(problem, options, solve_start) {
+            adopt_candidate_if_better(
+                &mut result,
+                candidate,
+                options,
+                "Auxiliary preprocessing fallback",
+                "auxiliary_preprocessing",
+            );
+        }
+    }
 
     if !matches!(result.status, SolveStatus::Optimal) {
         if let Some(slack_result) = dispatch_failure_recovery(

--- a/src/options.rs
+++ b/src/options.rs
@@ -120,6 +120,9 @@ pub struct SolverOptions {
     /// Enable preprocessing to eliminate fixed variables and redundant constraints.
     /// Default: true.
     pub enable_preprocessing: bool,
+    /// Maximum accepted residual for auxiliary equality-block solves during
+    /// preprocessing. Default: 1e-8.
+    pub auxiliary_tol: f64,
     /// Detect linear constraints and skip their Hessian contribution.
     /// Default: true.
     pub detect_linear_constraints: bool,
@@ -275,6 +278,7 @@ impl Default for SolverOptions {
             enable_lbfgs_fallback: true,
             enable_al_fallback: true,
             enable_preprocessing: true,
+            auxiliary_tol: 1e-8,
             detect_linear_constraints: true,
             enable_sqp_fallback: true,
             hessian_approximation_lbfgs: false,

--- a/tests/ipm_paths.rs
+++ b/tests/ipm_paths.rs
@@ -385,6 +385,63 @@ impl NlpProblem for PreprocessingProblem {
     }
 }
 
+struct AuxiliaryBasinGuardProblem;
+
+impl NlpProblem for AuxiliaryBasinGuardProblem {
+    fn num_variables(&self) -> usize { 2 }
+    fn num_constraints(&self) -> usize { 1 }
+
+    fn bounds(&self, x_l: &mut [f64], x_u: &mut [f64]) {
+        x_l[0] = f64::NEG_INFINITY; x_u[0] = f64::INFINITY;
+        x_l[1] = f64::NEG_INFINITY; x_u[1] = f64::INFINITY;
+    }
+
+    fn constraint_bounds(&self, g_l: &mut [f64], g_u: &mut [f64]) {
+        g_l[0] = 1.0;
+        g_u[0] = 1.0;
+    }
+
+    fn initial_point(&self, x0: &mut [f64]) {
+        x0[0] = -0.8;
+        x0[1] = 0.5;
+    }
+
+    fn objective(&self, x: &[f64], _new_x: bool, obj: &mut f64) -> bool {
+        *obj = (x[0] + 1.0) * (x[0] + 1.0) + x[1] * x[1];
+        true
+    }
+
+    fn gradient(&self, x: &[f64], _new_x: bool, grad: &mut [f64]) -> bool {
+        grad[0] = 2.0 * (x[0] + 1.0);
+        grad[1] = 2.0 * x[1];
+        true
+    }
+
+    fn constraints(&self, x: &[f64], _new_x: bool, g: &mut [f64]) -> bool {
+        g[0] = x[0] * x[0];
+        true
+    }
+
+    fn jacobian_structure(&self) -> (Vec<usize>, Vec<usize>) {
+        (vec![0], vec![0])
+    }
+
+    fn jacobian_values(&self, x: &[f64], _new_x: bool, vals: &mut [f64]) -> bool {
+        vals[0] = 2.0 * x[0];
+        true
+    }
+
+    fn hessian_structure(&self) -> (Vec<usize>, Vec<usize>) {
+        (vec![0, 1], vec![0, 1])
+    }
+
+    fn hessian_values(&self, _x: &[f64], _new_x: bool, obj_factor: f64, lambda: &[f64], vals: &mut [f64]) -> bool {
+        vals[0] = 2.0 * obj_factor + 2.0 * lambda[0];
+        vals[1] = 2.0 * obj_factor;
+        true
+    }
+}
+
 #[test]
 fn ipm_preprocessing_integration() {
     let problem = PreprocessingProblem;
@@ -399,6 +456,31 @@ fn ipm_preprocessing_integration() {
     assert!((result.x[1] - 0.5).abs() < 1e-4, "x1={}, expected 0.5", result.x[1]);
     assert!((result.x[2] - 0.5).abs() < 1e-4, "x2={}, expected 0.5", result.x[2]);
     assert!((result.objective - 0.5).abs() < 1e-4, "obj={}, expected 0.5", result.objective);
+}
+
+#[test]
+fn auxiliary_preprocessing_does_not_preempt_successful_main_solve() {
+    let problem = AuxiliaryBasinGuardProblem;
+    let options = SolverOptions {
+        print_level: 0,
+        enable_preprocessing: true,
+        enable_al_fallback: false,
+        enable_sqp_fallback: false,
+        max_iter: 200,
+        tol: 1e-8,
+        ..SolverOptions::default()
+    };
+
+    let result = ripopt::solve(&problem, &options);
+
+    assert_eq!(result.status, SolveStatus::Optimal, "Expected Optimal, got {:?}", result.status);
+    assert!((result.x[0] + 1.0).abs() < 1e-4, "x0={}, expected -1.0", result.x[0]);
+    assert!(result.x[1].abs() < 1e-4, "x1={}, expected 0.0", result.x[1]);
+    assert!(
+        result.diagnostics.fallback_used.as_deref() != Some("auxiliary_preprocessing"),
+        "auxiliary preprocessing should not preempt a successful main solve: {:?}",
+        result.diagnostics.fallback_used
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `AuxiliaryBlockProblem` as an internal `NlpProblem` wrapper for BTD equality blocks.
- Add auxiliary block solve policy that recursively calls `ripopt::solve` with preprocessing disabled, clears incompatible warm-start/scaling options, accepts only `Optimal`/`Acceptable` block solves below `auxiliary_tol`, and returns structured errors on failure.
- Seed the full solve from accepted auxiliary block solutions and expose `auxiliary_tol` through Rust options, C API, AMPL CLI parsing/help, and docs.

## Tests run

- `cargo test auxiliary_preprocessing` - passed, 33 tests.
- `cargo test` - passed, including doc test; warnings were existing unreachable-code warnings in L-BFGS test/example code.
- `cargo nextest run` - passed, 324 passed and 25 skipped; also reported an existing `.config/nextest.toml` unknown-key warning.
- `cargo build --release` - passed.
- `cc examples/c_api_test.c -I. -Ltarget/release -lripopt -Wl,-rpath,/home/bernalde/repos/ripopt/target/release -o /tmp/ripopt_c_api_test -lm` - passed.
- `cc examples/c_rosenbrock.c -I. -Ltarget/release -lripopt -Wl,-rpath,/home/bernalde/repos/ripopt/target/release -o /tmp/ripopt_c_rosenbrock -lm` - passed.
- `cc examples/c_hs035.c -I. -Ltarget/release -lripopt -Wl,-rpath,/home/bernalde/repos/ripopt/target/release -o /tmp/ripopt_c_hs035 -lm` - passed.
- `cc examples/c_example_with_options.c -I. -Ltarget/release -lripopt -Wl,-rpath,/home/bernalde/repos/ripopt/target/release -o /tmp/ripopt_c_example_with_options -lm` - passed.
- `/tmp/ripopt_c_api_test` - passed.
- `/tmp/ripopt_c_rosenbrock` - passed.
- `/tmp/ripopt_c_hs035` - passed.
- `/tmp/ripopt_c_example_with_options` - passed.

## Notes

- No documented formatting command is enforced in CI; `cargo fmt` was not left applied because it reformats unrelated files in this repository.
- Pre-existing untracked local files `.codex` and `temp.jl.txt` were not staged.

Closes #5
