### PR TITLE
Implement auxiliary reduced preprocessing

### DIFF
--- a/src/auxiliary_preprocessing.rs
+++ b/src/auxiliary_preprocessing.rs
@@ -301,64 +301,301 @@ impl NlpProblem for AuxiliaryBlockProblem<'_> {
     }
 }
 
-pub(crate) struct SeededInitialPointProblem<'a> {
+#[allow(dead_code)]
+pub(crate) struct AuxiliaryReducedProblem<'a> {
     inner: &'a dyn NlpProblem,
-    x0: Vec<f64>,
+    n_orig: usize,
+    m_orig: usize,
+    fixed_x: Vec<f64>,
+    var_map: Vec<usize>,
+    constr_map: Vec<usize>,
+    jac_rows: Vec<usize>,
+    jac_cols: Vec<usize>,
+    jac_entry_map: Vec<usize>,
+    inner_jac_nnz: usize,
+    hess_rows: Vec<usize>,
+    hess_cols: Vec<usize>,
+    hess_entry_map: Vec<usize>,
+    inner_hess_nnz: usize,
 }
 
-impl<'a> SeededInitialPointProblem<'a> {
-    pub(crate) fn new(inner: &'a dyn NlpProblem, x0: Vec<f64>) -> Self {
-        Self { inner, x0 }
+impl<'a> AuxiliaryReducedProblem<'a> {
+    pub(crate) fn new(
+        inner: &'a dyn NlpProblem,
+        candidates: &[PresolveCandidate],
+        fixed_x: Vec<f64>,
+    ) -> Result<Self, AuxiliarySolveError> {
+        let n_orig = inner.num_variables();
+        let m_orig = inner.num_constraints();
+        if fixed_x.len() != n_orig {
+            return Err(AuxiliarySolveError::InvalidBlock {
+                block: EqualityBlock {
+                    rows: Vec::new(),
+                    vars: Vec::new(),
+                },
+                reason: "fixed_x length does not match problem variables",
+            });
+        }
+
+        let mut fixed_vars = vec![false; n_orig];
+        let mut removed_constraints = vec![false; m_orig];
+        for candidate in candidates {
+            for block in &candidate.blocks {
+                validate_auxiliary_block(block, &fixed_x, n_orig, m_orig)?;
+                for &var in &block.vars {
+                    fixed_vars[var] = true;
+                }
+                for &row in &block.rows {
+                    removed_constraints[row] = true;
+                }
+            }
+        }
+
+        let var_map: Vec<_> = (0..n_orig).filter(|&var| !fixed_vars[var]).collect();
+        let constr_map: Vec<_> = (0..m_orig)
+            .filter(|&row| !removed_constraints[row])
+            .collect();
+
+        let mut orig_to_reduced_var = vec![None; n_orig];
+        for (reduced, &orig) in var_map.iter().enumerate() {
+            orig_to_reduced_var[orig] = Some(reduced);
+        }
+        let mut orig_to_reduced_constr = vec![None; m_orig];
+        for (reduced, &orig) in constr_map.iter().enumerate() {
+            orig_to_reduced_constr[orig] = Some(reduced);
+        }
+
+        let (inner_jac_rows, inner_jac_cols) = inner.jacobian_structure();
+        let mut jac_rows = Vec::new();
+        let mut jac_cols = Vec::new();
+        let mut jac_entry_map = Vec::new();
+        for (idx, (&row, &col)) in inner_jac_rows.iter().zip(inner_jac_cols.iter()).enumerate() {
+            if row >= m_orig || col >= n_orig {
+                continue;
+            }
+            if let (Some(reduced_row), Some(reduced_col)) =
+                (orig_to_reduced_constr[row], orig_to_reduced_var[col])
+            {
+                jac_rows.push(reduced_row);
+                jac_cols.push(reduced_col);
+                jac_entry_map.push(idx);
+            }
+        }
+
+        let (inner_hess_rows, inner_hess_cols) = inner.hessian_structure();
+        let mut hess_rows = Vec::new();
+        let mut hess_cols = Vec::new();
+        let mut hess_entry_map = Vec::new();
+        for (idx, (&row, &col)) in inner_hess_rows
+            .iter()
+            .zip(inner_hess_cols.iter())
+            .enumerate()
+        {
+            if row >= n_orig || col >= n_orig {
+                continue;
+            }
+            if let (Some(reduced_row), Some(reduced_col)) =
+                (orig_to_reduced_var[row], orig_to_reduced_var[col])
+            {
+                if reduced_row >= reduced_col {
+                    hess_rows.push(reduced_row);
+                    hess_cols.push(reduced_col);
+                } else {
+                    hess_rows.push(reduced_col);
+                    hess_cols.push(reduced_row);
+                }
+                hess_entry_map.push(idx);
+            }
+        }
+
+        Ok(Self {
+            inner,
+            n_orig,
+            m_orig,
+            fixed_x,
+            var_map,
+            constr_map,
+            jac_rows,
+            jac_cols,
+            jac_entry_map,
+            inner_jac_nnz: inner_jac_rows.len(),
+            hess_rows,
+            hess_cols,
+            hess_entry_map,
+            inner_hess_nnz: inner_hess_rows.len(),
+        })
+    }
+
+    pub(crate) fn did_reduce(&self) -> bool {
+        self.var_map.len() < self.n_orig || self.constr_map.len() < self.m_orig
+    }
+
+    pub(crate) fn num_fixed(&self) -> usize {
+        self.n_orig - self.var_map.len()
+    }
+
+    pub(crate) fn num_removed_constraints(&self) -> usize {
+        self.m_orig - self.constr_map.len()
+    }
+
+    fn expand_x(&self, x_reduced: &[f64]) -> Vec<f64> {
+        let mut x_full = self.fixed_x.clone();
+        for (reduced, &orig) in self.var_map.iter().enumerate() {
+            x_full[orig] = x_reduced[reduced];
+        }
+        x_full
+    }
+
+    pub(crate) fn unmap_solution(&self, reduced: &SolveResult) -> SolveResult {
+        let x_full = self.expand_x(&reduced.x);
+
+        let mut constraint_multipliers = vec![0.0; self.m_orig];
+        for (reduced_idx, &orig_idx) in self.constr_map.iter().enumerate() {
+            if reduced_idx < reduced.constraint_multipliers.len() {
+                constraint_multipliers[orig_idx] = reduced.constraint_multipliers[reduced_idx];
+            }
+        }
+
+        let mut bound_multipliers_lower = vec![0.0; self.n_orig];
+        let mut bound_multipliers_upper = vec![0.0; self.n_orig];
+        for (reduced_idx, &orig_idx) in self.var_map.iter().enumerate() {
+            if reduced_idx < reduced.bound_multipliers_lower.len() {
+                bound_multipliers_lower[orig_idx] = reduced.bound_multipliers_lower[reduced_idx];
+            }
+            if reduced_idx < reduced.bound_multipliers_upper.len() {
+                bound_multipliers_upper[orig_idx] = reduced.bound_multipliers_upper[reduced_idx];
+            }
+        }
+
+        let mut objective = reduced.objective;
+        let _ = self.inner.objective(&x_full, true, &mut objective);
+
+        let mut constraint_values = vec![0.0; self.m_orig];
+        if self.m_orig > 0 {
+            let _ = self
+                .inner
+                .constraints(&x_full, true, &mut constraint_values);
+        }
+
+        SolveResult {
+            x: x_full,
+            objective,
+            constraint_multipliers,
+            bound_multipliers_lower,
+            bound_multipliers_upper,
+            constraint_values,
+            status: reduced.status,
+            iterations: reduced.iterations,
+            diagnostics: reduced.diagnostics.clone(),
+        }
     }
 }
 
-impl NlpProblem for SeededInitialPointProblem<'_> {
+impl NlpProblem for AuxiliaryReducedProblem<'_> {
     fn num_variables(&self) -> usize {
-        self.inner.num_variables()
+        self.var_map.len()
     }
 
     fn num_constraints(&self) -> usize {
-        self.inner.num_constraints()
+        self.constr_map.len()
     }
 
     fn bounds(&self, x_l: &mut [f64], x_u: &mut [f64]) {
-        self.inner.bounds(x_l, x_u);
+        let mut x_l_full = vec![0.0; self.n_orig];
+        let mut x_u_full = vec![0.0; self.n_orig];
+        self.inner.bounds(&mut x_l_full, &mut x_u_full);
+        for (reduced, &orig) in self.var_map.iter().enumerate() {
+            x_l[reduced] = x_l_full[orig];
+            x_u[reduced] = x_u_full[orig];
+        }
     }
 
     fn constraint_bounds(&self, g_l: &mut [f64], g_u: &mut [f64]) {
-        self.inner.constraint_bounds(g_l, g_u);
+        let mut g_l_full = vec![0.0; self.m_orig];
+        let mut g_u_full = vec![0.0; self.m_orig];
+        self.inner.constraint_bounds(&mut g_l_full, &mut g_u_full);
+        for (reduced, &orig) in self.constr_map.iter().enumerate() {
+            g_l[reduced] = g_l_full[orig];
+            g_u[reduced] = g_u_full[orig];
+        }
     }
 
     fn initial_point(&self, x0: &mut [f64]) {
-        x0.copy_from_slice(&self.x0);
+        for (reduced, &orig) in self.var_map.iter().enumerate() {
+            x0[reduced] = self.fixed_x[orig];
+        }
     }
 
     fn initial_multipliers(&self, lam_g: &mut [f64], z_l: &mut [f64], z_u: &mut [f64]) -> bool {
-        self.inner.initial_multipliers(lam_g, z_l, z_u)
+        let mut lam_g_full = vec![0.0; self.m_orig];
+        let mut z_l_full = vec![0.0; self.n_orig];
+        let mut z_u_full = vec![0.0; self.n_orig];
+        if !self
+            .inner
+            .initial_multipliers(&mut lam_g_full, &mut z_l_full, &mut z_u_full)
+        {
+            return false;
+        }
+        for (reduced, &orig) in self.constr_map.iter().enumerate() {
+            lam_g[reduced] = lam_g_full[orig];
+        }
+        for (reduced, &orig) in self.var_map.iter().enumerate() {
+            z_l[reduced] = z_l_full[orig];
+            z_u[reduced] = z_u_full[orig];
+        }
+        true
     }
 
     fn objective(&self, x: &[f64], new_x: bool, obj: &mut f64) -> bool {
-        self.inner.objective(x, new_x, obj)
+        let x_full = self.expand_x(x);
+        self.inner.objective(&x_full, new_x, obj)
     }
 
     fn gradient(&self, x: &[f64], new_x: bool, grad: &mut [f64]) -> bool {
-        self.inner.gradient(x, new_x, grad)
+        let x_full = self.expand_x(x);
+        let mut grad_full = vec![0.0; self.n_orig];
+        if !self.inner.gradient(&x_full, new_x, &mut grad_full) {
+            return false;
+        }
+        for (reduced, &orig) in self.var_map.iter().enumerate() {
+            grad[reduced] = grad_full[orig];
+        }
+        true
     }
 
     fn constraints(&self, x: &[f64], new_x: bool, g: &mut [f64]) -> bool {
-        self.inner.constraints(x, new_x, g)
+        let x_full = self.expand_x(x);
+        let mut g_full = vec![0.0; self.m_orig];
+        if !self.inner.constraints(&x_full, new_x, &mut g_full) {
+            return false;
+        }
+        for (reduced, &orig) in self.constr_map.iter().enumerate() {
+            g[reduced] = g_full[orig];
+        }
+        true
     }
 
     fn jacobian_structure(&self) -> (Vec<usize>, Vec<usize>) {
-        self.inner.jacobian_structure()
+        (self.jac_rows.clone(), self.jac_cols.clone())
     }
 
     fn jacobian_values(&self, x: &[f64], new_x: bool, vals: &mut [f64]) -> bool {
-        self.inner.jacobian_values(x, new_x, vals)
+        if self.jac_entry_map.is_empty() {
+            return true;
+        }
+        let x_full = self.expand_x(x);
+        let mut inner_vals = vec![0.0; self.inner_jac_nnz];
+        if !self.inner.jacobian_values(&x_full, new_x, &mut inner_vals) {
+            return false;
+        }
+        for (reduced, &inner_idx) in self.jac_entry_map.iter().enumerate() {
+            vals[reduced] = inner_vals[inner_idx];
+        }
+        true
     }
 
     fn hessian_structure(&self) -> (Vec<usize>, Vec<usize>) {
-        self.inner.hessian_structure()
+        (self.hess_rows.clone(), self.hess_cols.clone())
     }
 
     fn hessian_values(
@@ -369,8 +606,27 @@ impl NlpProblem for SeededInitialPointProblem<'_> {
         lambda: &[f64],
         vals: &mut [f64],
     ) -> bool {
-        self.inner
-            .hessian_values(x, new_x, obj_factor, lambda, vals)
+        if self.hess_entry_map.is_empty() {
+            return true;
+        }
+
+        let x_full = self.expand_x(x);
+        let mut lambda_full = vec![0.0; self.m_orig];
+        for (reduced, &orig) in self.constr_map.iter().enumerate() {
+            lambda_full[orig] = lambda[reduced];
+        }
+
+        let mut inner_vals = vec![0.0; self.inner_hess_nnz];
+        if !self
+            .inner
+            .hessian_values(&x_full, new_x, obj_factor, &lambda_full, &mut inner_vals)
+        {
+            return false;
+        }
+        for (reduced, &inner_idx) in self.hess_entry_map.iter().enumerate() {
+            vals[reduced] = inner_vals[inner_idx];
+        }
+        true
     }
 }
 
@@ -1611,6 +1867,217 @@ mod tests {
         ) -> bool {
             true
         }
+    }
+
+    struct ReducedMappingProblem;
+
+    impl NlpProblem for ReducedMappingProblem {
+        fn num_variables(&self) -> usize {
+            4
+        }
+
+        fn num_constraints(&self) -> usize {
+            4
+        }
+
+        fn bounds(&self, x_l: &mut [f64], x_u: &mut [f64]) {
+            x_l[0] = -10.0;
+            x_u[0] = 10.0;
+            x_l[1] = 2.0;
+            x_u[1] = 2.0;
+            x_l[2] = -20.0;
+            x_u[2] = 20.0;
+            x_l[3] = 5.0;
+            x_u[3] = 5.0;
+        }
+
+        fn constraint_bounds(&self, g_l: &mut [f64], g_u: &mut [f64]) {
+            g_l[0] = 0.0;
+            g_u[0] = 0.0;
+            g_l[1] = f64::NEG_INFINITY;
+            g_u[1] = 100.0;
+            g_l[2] = 0.0;
+            g_u[2] = 0.0;
+            g_l[3] = 1.0;
+            g_u[3] = 1.0;
+        }
+
+        fn initial_point(&self, x0: &mut [f64]) {
+            x0.copy_from_slice(&[9.0, 2.0, 8.0, 5.0]);
+        }
+
+        fn objective(&self, x: &[f64], _new_x: bool, obj: &mut f64) -> bool {
+            *obj = x[0] * x[0] + 4.0 * x[0] * x[2] + 3.0 * x[2] * x[2] + 5.0 * x[1] + 7.0 * x[3];
+            true
+        }
+
+        fn gradient(&self, x: &[f64], _new_x: bool, grad: &mut [f64]) -> bool {
+            grad[0] = 2.0 * x[0] + 4.0 * x[2];
+            grad[1] = 5.0;
+            grad[2] = 4.0 * x[0] + 6.0 * x[2];
+            grad[3] = 7.0;
+            true
+        }
+
+        fn constraints(&self, x: &[f64], _new_x: bool, g: &mut [f64]) -> bool {
+            g[0] = x[1] - 2.0;
+            g[1] = x[0] + 10.0 * x[1] + 2.0 * x[2];
+            g[2] = x[3] - 5.0;
+            g[3] = x[0] * x[0] + x[2] - 3.0 * x[3];
+            true
+        }
+
+        fn jacobian_structure(&self) -> (Vec<usize>, Vec<usize>) {
+            (vec![0, 1, 1, 1, 2, 3, 3, 3], vec![1, 0, 1, 2, 3, 0, 2, 3])
+        }
+
+        fn jacobian_values(&self, x: &[f64], _new_x: bool, vals: &mut [f64]) -> bool {
+            vals[0] = 1.0;
+            vals[1] = 1.0;
+            vals[2] = 10.0;
+            vals[3] = 2.0;
+            vals[4] = 1.0;
+            vals[5] = 2.0 * x[0];
+            vals[6] = 1.0;
+            vals[7] = -3.0;
+            true
+        }
+
+        fn hessian_structure(&self) -> (Vec<usize>, Vec<usize>) {
+            (vec![0, 1, 2, 2, 3, 3], vec![0, 0, 0, 2, 2, 3])
+        }
+
+        fn hessian_values(
+            &self,
+            _x: &[f64],
+            _new_x: bool,
+            obj_factor: f64,
+            lambda: &[f64],
+            vals: &mut [f64],
+        ) -> bool {
+            vals[0] = 2.0 * obj_factor + 2.0 * lambda[3];
+            vals[1] = 0.0;
+            vals[2] = 4.0 * obj_factor;
+            vals[3] = 6.0 * obj_factor;
+            vals[4] = 0.0;
+            vals[5] = 0.0;
+            true
+        }
+    }
+
+    fn reduced_mapping_problem<'a>(problem: &'a dyn NlpProblem) -> AuxiliaryReducedProblem<'a> {
+        let candidates = vec![PresolveCandidate {
+            blocks: vec![
+                EqualityBlock {
+                    rows: vec![0],
+                    vars: vec![1],
+                },
+                EqualityBlock {
+                    rows: vec![2],
+                    vars: vec![3],
+                },
+            ],
+        }];
+        AuxiliaryReducedProblem::new(problem, &candidates, vec![9.0, 2.0, 8.0, 5.0]).unwrap()
+    }
+
+    #[test]
+    fn auxiliary_reduced_problem_expands_evaluations_through_fixed_auxiliaries() {
+        let problem = ReducedMappingProblem;
+        let reduced = reduced_mapping_problem(&problem);
+
+        assert!(reduced.did_reduce());
+        assert_eq!(reduced.num_fixed(), 2);
+        assert_eq!(reduced.num_removed_constraints(), 2);
+        assert_eq!(reduced.num_variables(), 2);
+        assert_eq!(reduced.num_constraints(), 2);
+        assert_eq!(reduced.var_map, vec![0, 2]);
+        assert_eq!(reduced.constr_map, vec![1, 3]);
+
+        let mut x0 = vec![0.0; 2];
+        reduced.initial_point(&mut x0);
+        assert_eq!(x0, vec![9.0, 8.0]);
+
+        let mut x_l = vec![0.0; 2];
+        let mut x_u = vec![0.0; 2];
+        reduced.bounds(&mut x_l, &mut x_u);
+        assert_eq!(x_l, vec![-10.0, -20.0]);
+        assert_eq!(x_u, vec![10.0, 20.0]);
+
+        let mut g_l = vec![0.0; 2];
+        let mut g_u = vec![0.0; 2];
+        reduced.constraint_bounds(&mut g_l, &mut g_u);
+        assert_eq!(g_l, vec![f64::NEG_INFINITY, 1.0]);
+        assert_eq!(g_u, vec![100.0, 1.0]);
+
+        let x_reduced = vec![11.0, 13.0];
+        let mut obj = 0.0;
+        assert!(reduced.objective(&x_reduced, true, &mut obj));
+        assert_eq!(obj, 1245.0);
+
+        let mut grad = vec![0.0; 2];
+        assert!(reduced.gradient(&x_reduced, true, &mut grad));
+        assert_eq!(grad, vec![74.0, 122.0]);
+
+        let mut g = vec![0.0; 2];
+        assert!(reduced.constraints(&x_reduced, true, &mut g));
+        assert_eq!(g, vec![57.0, 119.0]);
+    }
+
+    #[test]
+    fn auxiliary_reduced_problem_remaps_jacobian_entries() {
+        let problem = ReducedMappingProblem;
+        let reduced = reduced_mapping_problem(&problem);
+
+        let (rows, cols) = reduced.jacobian_structure();
+        assert_eq!(rows, vec![0, 0, 1, 1]);
+        assert_eq!(cols, vec![0, 1, 0, 1]);
+
+        let mut vals = vec![0.0; rows.len()];
+        assert!(reduced.jacobian_values(&[11.0, 13.0], true, &mut vals));
+        assert_eq!(vals, vec![1.0, 2.0, 22.0, 1.0]);
+    }
+
+    #[test]
+    fn auxiliary_reduced_problem_remaps_sparse_lower_hessian_entries() {
+        let problem = ReducedMappingProblem;
+        let reduced = reduced_mapping_problem(&problem);
+
+        let (rows, cols) = reduced.hessian_structure();
+        assert_eq!(rows, vec![0, 1, 1]);
+        assert_eq!(cols, vec![0, 0, 1]);
+
+        let mut vals = vec![0.0; rows.len()];
+        assert!(reduced.hessian_values(&[11.0, 13.0], true, 0.5, &[7.0, 11.0], &mut vals));
+        assert_eq!(vals, vec![23.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn auxiliary_reduced_problem_unmaps_full_solution() {
+        let problem = ReducedMappingProblem;
+        let reduced = reduced_mapping_problem(&problem);
+        let reduced_result = SolveResult {
+            x: vec![11.0, 13.0],
+            objective: -1.0,
+            constraint_multipliers: vec![7.0, 11.0],
+            bound_multipliers_lower: vec![0.1, 0.2],
+            bound_multipliers_upper: vec![0.3, 0.4],
+            constraint_values: vec![-1.0, -1.0],
+            status: SolveStatus::Optimal,
+            iterations: 12,
+            diagnostics: Default::default(),
+        };
+
+        let full = reduced.unmap_solution(&reduced_result);
+
+        assert_eq!(full.x, vec![11.0, 2.0, 13.0, 5.0]);
+        assert_eq!(full.objective, 1245.0);
+        assert_eq!(full.constraint_values, vec![0.0, 57.0, 0.0, 119.0]);
+        assert_eq!(full.constraint_multipliers, vec![0.0, 7.0, 0.0, 11.0]);
+        assert_eq!(full.bound_multipliers_lower, vec![0.1, 0.0, 0.2, 0.0]);
+        assert_eq!(full.bound_multipliers_upper, vec![0.3, 0.0, 0.4, 0.0]);
+        assert_eq!(full.status, SolveStatus::Optimal);
+        assert_eq!(full.iterations, 12);
     }
 
     #[test]

--- a/src/auxiliary_preprocessing.rs
+++ b/src/auxiliary_preprocessing.rs
@@ -50,6 +50,11 @@ pub(crate) enum AuxiliarySolveError {
         status: SolveStatus,
         residual: f64,
     },
+    RankDeficientBlock {
+        block: EqualityBlock,
+        rank: usize,
+        expected: usize,
+    },
 }
 
 #[allow(dead_code)]
@@ -342,6 +347,15 @@ impl<'a> AuxiliaryReducedProblem<'a> {
         for candidate in candidates {
             for block in &candidate.blocks {
                 validate_auxiliary_block(block, &fixed_x, n_orig, m_orig)?;
+                let rank = auxiliary_block_jacobian_rank(inner, block, &fixed_x)?;
+                let expected = block.vars.len();
+                if rank < expected {
+                    return Err(AuxiliarySolveError::RankDeficientBlock {
+                        block: block.clone(),
+                        rank,
+                        expected,
+                    });
+                }
                 for &var in &block.vars {
                     fixed_vars[var] = true;
                 }
@@ -436,6 +450,20 @@ impl<'a> AuxiliaryReducedProblem<'a> {
 
     pub(crate) fn num_removed_constraints(&self) -> usize {
         self.m_orig - self.constr_map.len()
+    }
+
+    pub(crate) fn reduced_x_scaling(&self, scaling: &[f64]) -> Option<Vec<f64>> {
+        if scaling.len() != self.n_orig {
+            return None;
+        }
+        Some(self.var_map.iter().map(|&orig| scaling[orig]).collect())
+    }
+
+    pub(crate) fn reduced_g_scaling(&self, scaling: &[f64]) -> Option<Vec<f64>> {
+        if scaling.len() != self.m_orig {
+            return None;
+        }
+        Some(self.constr_map.iter().map(|&orig| scaling[orig]).collect())
     }
 
     fn expand_x(&self, x_reduced: &[f64]) -> Vec<f64> {
@@ -628,6 +656,88 @@ impl NlpProblem for AuxiliaryReducedProblem<'_> {
         }
         true
     }
+}
+
+fn auxiliary_block_jacobian_rank(
+    inner: &dyn NlpProblem,
+    block: &EqualityBlock,
+    fixed_x: &[f64],
+) -> Result<usize, AuxiliarySolveError> {
+    let block_problem = AuxiliaryBlockProblem::new(inner, block, fixed_x)?;
+    let rows = block_problem.rows.len();
+    let cols = block_problem.vars.len();
+    if rows == 0 || cols == 0 {
+        return Ok(0);
+    }
+
+    let x_block: Vec<_> = block_problem
+        .vars
+        .iter()
+        .map(|&var| fixed_x[var])
+        .collect();
+    let mut jac_vals = vec![0.0; block_problem.jac_rows.len()];
+    if !block_problem.jacobian_values(&x_block, true, &mut jac_vals) {
+        return Err(AuxiliarySolveError::EvaluationFailed {
+            block: block.clone(),
+        });
+    }
+
+    let mut dense = vec![0.0; rows * cols];
+    for (idx, (&row, &col)) in block_problem
+        .jac_rows
+        .iter()
+        .zip(block_problem.jac_cols.iter())
+        .enumerate()
+    {
+        dense[row * cols + col] += jac_vals[idx];
+    }
+    Ok(dense_numeric_rank(&mut dense, rows, cols))
+}
+
+fn dense_numeric_rank(matrix: &mut [f64], rows: usize, cols: usize) -> usize {
+    let max_abs = matrix
+        .iter()
+        .fold(0.0_f64, |acc, &value| acc.max(value.abs()));
+    if max_abs == 0.0 || !max_abs.is_finite() {
+        return 0;
+    }
+
+    let tol = (rows.max(cols) as f64) * max_abs * 1e-10;
+    let mut rank = 0usize;
+    for col in 0..cols {
+        let pivot_row = (rank..rows).max_by(|&a, &b| {
+            matrix[a * cols + col]
+                .abs()
+                .partial_cmp(&matrix[b * cols + col].abs())
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        let Some(pivot_row) = pivot_row else {
+            break;
+        };
+        if matrix[pivot_row * cols + col].abs() <= tol {
+            continue;
+        }
+
+        if pivot_row != rank {
+            for j in 0..cols {
+                matrix.swap(rank * cols + j, pivot_row * cols + j);
+            }
+        }
+
+        let pivot = matrix[rank * cols + col];
+        for row in (rank + 1)..rows {
+            let factor = matrix[row * cols + col] / pivot;
+            matrix[row * cols + col] = 0.0;
+            for j in (col + 1)..cols {
+                matrix[row * cols + j] -= factor * matrix[rank * cols + j];
+            }
+        }
+        rank += 1;
+        if rank == rows {
+            break;
+        }
+    }
+    rank
 }
 
 pub(crate) fn solve_auxiliary_blocks(
@@ -1965,6 +2075,79 @@ mod tests {
         }
     }
 
+    struct RankDeficientAuxProblem;
+
+    impl NlpProblem for RankDeficientAuxProblem {
+        fn num_variables(&self) -> usize {
+            2
+        }
+
+        fn num_constraints(&self) -> usize {
+            2
+        }
+
+        fn bounds(&self, x_l: &mut [f64], x_u: &mut [f64]) {
+            x_l.fill(f64::NEG_INFINITY);
+            x_u.fill(f64::INFINITY);
+        }
+
+        fn constraint_bounds(&self, g_l: &mut [f64], g_u: &mut [f64]) {
+            g_l[0] = 0.0;
+            g_u[0] = 0.0;
+            g_l[1] = f64::NEG_INFINITY;
+            g_u[1] = 10.0;
+        }
+
+        fn initial_point(&self, x0: &mut [f64]) {
+            x0[0] = 0.0;
+            x0[1] = 1.0;
+        }
+
+        fn objective(&self, x: &[f64], _new_x: bool, obj: &mut f64) -> bool {
+            *obj = x[1] * x[1];
+            true
+        }
+
+        fn gradient(&self, x: &[f64], _new_x: bool, grad: &mut [f64]) -> bool {
+            grad[0] = 0.0;
+            grad[1] = 2.0 * x[1];
+            true
+        }
+
+        fn constraints(&self, x: &[f64], _new_x: bool, g: &mut [f64]) -> bool {
+            g[0] = x[0] * x[0];
+            g[1] = x[1];
+            true
+        }
+
+        fn jacobian_structure(&self) -> (Vec<usize>, Vec<usize>) {
+            (vec![0, 1], vec![0, 1])
+        }
+
+        fn jacobian_values(&self, x: &[f64], _new_x: bool, vals: &mut [f64]) -> bool {
+            vals[0] = 2.0 * x[0];
+            vals[1] = 1.0;
+            true
+        }
+
+        fn hessian_structure(&self) -> (Vec<usize>, Vec<usize>) {
+            (vec![0, 1], vec![0, 1])
+        }
+
+        fn hessian_values(
+            &self,
+            _x: &[f64],
+            _new_x: bool,
+            obj_factor: f64,
+            lambda: &[f64],
+            vals: &mut [f64],
+        ) -> bool {
+            vals[0] = 2.0 * lambda[0];
+            vals[1] = 2.0 * obj_factor;
+            true
+        }
+    }
+
     fn reduced_mapping_problem<'a>(problem: &'a dyn NlpProblem) -> AuxiliaryReducedProblem<'a> {
         let candidates = vec![PresolveCandidate {
             blocks: vec![
@@ -1993,6 +2176,14 @@ mod tests {
         assert_eq!(reduced.num_constraints(), 2);
         assert_eq!(reduced.var_map, vec![0, 2]);
         assert_eq!(reduced.constr_map, vec![1, 3]);
+        assert_eq!(
+            reduced.reduced_x_scaling(&[1.0, 2.0, 3.0, 4.0]),
+            Some(vec![1.0, 3.0])
+        );
+        assert_eq!(
+            reduced.reduced_g_scaling(&[10.0, 20.0, 30.0, 40.0]),
+            Some(vec![20.0, 40.0])
+        );
 
         let mut x0 = vec![0.0; 2];
         reduced.initial_point(&mut x0);
@@ -2078,6 +2269,36 @@ mod tests {
         assert_eq!(full.bound_multipliers_upper, vec![0.3, 0.0, 0.4, 0.0]);
         assert_eq!(full.status, SolveStatus::Optimal);
         assert_eq!(full.iterations, 12);
+    }
+
+    #[test]
+    fn auxiliary_reduced_problem_rejects_rank_deficient_auxiliary_block() {
+        let problem = RankDeficientAuxProblem;
+        let candidates = vec![PresolveCandidate {
+            blocks: vec![EqualityBlock {
+                rows: vec![0],
+                vars: vec![0],
+            }],
+        }];
+
+        let err = match AuxiliaryReducedProblem::new(&problem, &candidates, vec![0.0, 1.0]) {
+            Ok(_) => panic!("rank-deficient auxiliary block should not reduce"),
+            Err(err) => err,
+        };
+
+        match err {
+            AuxiliarySolveError::RankDeficientBlock {
+                block,
+                rank,
+                expected,
+            } => {
+                assert_eq!(block.rows, vec![0]);
+                assert_eq!(block.vars, vec![0]);
+                assert_eq!(rank, 0);
+                assert_eq!(expected, 1);
+            }
+            other => panic!("unexpected error: {:?}", other),
+        }
     }
 
     #[test]

--- a/src/ipm.rs
+++ b/src/ipm.rs
@@ -1632,9 +1632,9 @@ fn try_slow_optimal_slack_fallback<P: NlpProblem>(
 }
 
 /// Auxiliary preprocessing attempt: solve block-triangular equality
-/// subsystems first, use the solved full-space point as the initial point,
-/// then run a non-preprocessing recursive solve. The caller decides whether
-/// the seeded result improves on the normal solve.
+/// subsystems first, remove the solved auxiliary variables and equality rows,
+/// then run a non-preprocessing recursive solve on the reduced problem. The
+/// caller decides whether the unmapped result improves on the normal solve.
 fn try_auxiliary_preprocessed_solve<P: NlpProblem>(
     problem: &P,
     options: &SolverOptions,
@@ -1663,34 +1663,67 @@ fn try_auxiliary_preprocessed_solve<P: NlpProblem>(
                 return None;
             }
         };
+    let blocks_solved = outcome.blocks_solved;
+    let max_residual = outcome.max_residual;
 
     if options.print_level >= 5 {
         rip_log!(
             "ripopt: Auxiliary preprocessing solved {} block(s), max residual {:.2e}",
-            outcome.blocks_solved,
-            outcome.max_residual,
+            blocks_solved,
+            max_residual,
         );
     }
 
-    let seeded = crate::auxiliary_preprocessing::SeededInitialPointProblem::new(problem_dyn, outcome.x);
-    let mut seeded_opts = options.clone();
-    seeded_opts.enable_preprocessing = false;
+    let reduced =
+        match crate::auxiliary_preprocessing::AuxiliaryReducedProblem::new(problem_dyn, &candidates, outcome.x)
+        {
+            Ok(reduced) if reduced.did_reduce() => reduced,
+            Ok(_) => return None,
+            Err(err) => {
+                if options.print_level >= 5 {
+                    rip_log!("ripopt: Auxiliary preprocessing skipped after reduction failure: {:?}", err);
+                }
+                return None;
+            }
+        };
+
+    if options.print_level >= 5 {
+        rip_log!(
+            "ripopt: Auxiliary preprocessing reduced problem: {} fixed vars, {} removed constraints ({}x{} -> {}x{})",
+            reduced.num_fixed(),
+            reduced.num_removed_constraints(),
+            problem.num_variables(),
+            problem.num_constraints(),
+            reduced.num_variables(),
+            reduced.num_constraints(),
+        );
+    }
+
+    let mut reduced_opts = options.clone();
+    reduced_opts.enable_preprocessing = false;
+    reduced_opts.warm_start = false;
+    reduced_opts.warm_start_y = None;
+    reduced_opts.warm_start_z_l = None;
+    reduced_opts.warm_start_z_u = None;
+    reduced_opts.user_x_scaling = None;
+    reduced_opts.user_g_scaling = None;
     if options.max_wall_time > 0.0 {
         let remaining = options.max_wall_time - solve_start.elapsed().as_secs_f64();
         if remaining <= 0.1 {
             return None;
         }
-        seeded_opts.max_wall_time = remaining * 0.5;
+        reduced_opts.max_wall_time = remaining * 0.5;
     }
 
-    let result = solve(&seeded, &seeded_opts);
+    let reduced_result = solve(&reduced, &reduced_opts);
+    let result = reduced.unmap_solution(&reduced_result);
     if matches!(result.status, SolveStatus::Optimal) {
         return Some(result);
     }
 
     if options.print_level >= 5 {
         rip_log!(
-            "ripopt: Auxiliary-seeded solve failed ({:?}), retrying without auxiliary preprocessing",
+            "ripopt: Auxiliary-reduced solve failed ({:?}), retrying without auxiliary preprocessing",
             result.status,
         );
     }

--- a/src/ipm.rs
+++ b/src/ipm.rs
@@ -1705,8 +1705,14 @@ fn try_auxiliary_preprocessed_solve<P: NlpProblem>(
     reduced_opts.warm_start_y = None;
     reduced_opts.warm_start_z_l = None;
     reduced_opts.warm_start_z_u = None;
-    reduced_opts.user_x_scaling = None;
-    reduced_opts.user_g_scaling = None;
+    reduced_opts.user_x_scaling = options
+        .user_x_scaling
+        .as_ref()
+        .and_then(|scaling| reduced.reduced_x_scaling(scaling));
+    reduced_opts.user_g_scaling = options
+        .user_g_scaling
+        .as_ref()
+        .and_then(|scaling| reduced.reduced_g_scaling(scaling));
     if options.max_wall_time > 0.0 {
         let remaining = options.max_wall_time - solve_start.elapsed().as_secs_f64();
         if remaining <= 0.1 {

--- a/tests/ipm_paths.rs
+++ b/tests/ipm_paths.rs
@@ -442,6 +442,87 @@ impl NlpProblem for AuxiliaryBasinGuardProblem {
     }
 }
 
+struct AuxiliaryReducedFallbackProblem;
+
+impl NlpProblem for AuxiliaryReducedFallbackProblem {
+    fn num_variables(&self) -> usize {
+        2
+    }
+
+    fn num_constraints(&self) -> usize {
+        2
+    }
+
+    fn bounds(&self, x_l: &mut [f64], x_u: &mut [f64]) {
+        x_l[0] = f64::NEG_INFINITY;
+        x_u[0] = f64::INFINITY;
+        x_l[1] = f64::NEG_INFINITY;
+        x_u[1] = f64::INFINITY;
+    }
+
+    fn constraint_bounds(&self, g_l: &mut [f64], g_u: &mut [f64]) {
+        g_l[0] = 0.0;
+        g_u[0] = 0.0;
+        g_l[1] = f64::NEG_INFINITY;
+        g_u[1] = 10.0;
+    }
+
+    fn initial_point(&self, x0: &mut [f64]) {
+        x0[0] = 0.0;
+        x0[1] = 3.0;
+    }
+
+    fn objective(&self, x: &[f64], _new_x: bool, obj: &mut f64) -> bool {
+        if (x[0] - 2.0).abs() > 1e-8 {
+            return false;
+        }
+        *obj = -10.0 + x[0] + (x[1] - 3.0) * (x[1] - 3.0);
+        true
+    }
+
+    fn gradient(&self, x: &[f64], _new_x: bool, grad: &mut [f64]) -> bool {
+        if (x[0] - 2.0).abs() > 1e-8 {
+            return false;
+        }
+        grad[0] = 1.0;
+        grad[1] = 2.0 * (x[1] - 3.0);
+        true
+    }
+
+    fn constraints(&self, x: &[f64], _new_x: bool, g: &mut [f64]) -> bool {
+        g[0] = x[0] - 2.0;
+        g[1] = x[0] + x[1];
+        true
+    }
+
+    fn jacobian_structure(&self) -> (Vec<usize>, Vec<usize>) {
+        (vec![0, 1, 1], vec![0, 0, 1])
+    }
+
+    fn jacobian_values(&self, _x: &[f64], _new_x: bool, vals: &mut [f64]) -> bool {
+        vals[0] = 1.0;
+        vals[1] = 1.0;
+        vals[2] = 1.0;
+        true
+    }
+
+    fn hessian_structure(&self) -> (Vec<usize>, Vec<usize>) {
+        (vec![1], vec![1])
+    }
+
+    fn hessian_values(
+        &self,
+        _x: &[f64],
+        _new_x: bool,
+        obj_factor: f64,
+        _lambda: &[f64],
+        vals: &mut [f64],
+    ) -> bool {
+        vals[0] = 2.0 * obj_factor;
+        true
+    }
+}
+
 #[test]
 fn ipm_preprocessing_integration() {
     let problem = PreprocessingProblem;
@@ -481,6 +562,54 @@ fn auxiliary_preprocessing_does_not_preempt_successful_main_solve() {
         "auxiliary preprocessing should not preempt a successful main solve: {:?}",
         result.diagnostics.fallback_used
     );
+}
+
+#[test]
+fn auxiliary_reduced_fallback_adopts_full_space_solution() {
+    let problem = AuxiliaryReducedFallbackProblem;
+    let options = SolverOptions {
+        print_level: 0,
+        enable_preprocessing: true,
+        enable_al_fallback: false,
+        enable_sqp_fallback: false,
+        user_g_scaling: Some(vec![1.0, 0.5]),
+        ..SolverOptions::default()
+    };
+
+    let result = ripopt::solve(&problem, &options);
+
+    assert_eq!(
+        result.status,
+        SolveStatus::Optimal,
+        "Expected Optimal, got {:?}",
+        result.status
+    );
+    assert_eq!(
+        result.diagnostics.fallback_used.as_deref(),
+        Some("auxiliary_preprocessing")
+    );
+    assert_eq!(result.x.len(), 2);
+    assert!(
+        (result.x[0] - 2.0).abs() < 1e-8,
+        "x0={}, expected 2.0",
+        result.x[0]
+    );
+    assert!(
+        (result.x[1] - 3.0).abs() < 1e-6,
+        "x1={}, expected 3.0",
+        result.x[1]
+    );
+    assert!(
+        (result.objective + 8.0).abs() < 1e-8,
+        "obj={}, expected -8.0",
+        result.objective
+    );
+    assert_eq!(result.constraint_values.len(), 2);
+    assert!(result.constraint_values[0].abs() < 1e-8);
+    assert!((result.constraint_values[1] - 5.0).abs() < 1e-8);
+    assert_eq!(result.constraint_multipliers.len(), 2);
+    assert_eq!(result.bound_multipliers_lower.len(), 2);
+    assert_eq!(result.bound_multipliers_upper.len(), 2);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Added internal `AuxiliaryReducedProblem<'a>` to remove solved auxiliary variables and auxiliary equality rows while preserving reduced-to-full maps.
- Remapped objective, gradient, constraints, Jacobian, and lower-triangle Hessian callbacks through full-space expansion.
- Added `unmap_solution` to reconstruct full primal values, objective, constraints, retained constraint multipliers, and free-variable bound multipliers.
- Switched the auxiliary preprocessing fallback to solve the reduced NLP and unmap the result, rather than only seeding a full-space retry.

## Tests run

- `cargo test auxiliary_preprocessing` — passed: 38 tests passed; 182 filtered out. Existing unreachable-code warnings were emitted from `tests/lbfgs_ipm.rs`.
- `cargo test` — passed: all runnable unit, integration, and doctests passed. Repository-configured ignored tests remained ignored; existing unreachable-code warnings were emitted from `tests/lbfgs_ipm.rs` and `examples/lbfgs_hessian.rs`.
- `cargo nextest run` — passed: 330 tests passed; 25 skipped. Existing warnings were emitted for `.config/nextest.toml`, `tests/lbfgs_ipm.rs`, and `examples/lbfgs_hessian.rs`.
- `cargo test --doc` — passed: 1 doctest passed.
- `cargo build --release` — passed.
- `cc examples/c_api_test.c -I. -Ltarget/release -lripopt -Wl,-rpath,/home/bernalde/repos/ripopt/target/release -o /tmp/ripopt_c_api_test -lm` — passed.
- `cc examples/c_rosenbrock.c -I. -Ltarget/release -lripopt -Wl,-rpath,/home/bernalde/repos/ripopt/target/release -o /tmp/ripopt_c_rosenbrock -lm` — passed.
- `cc examples/c_hs035.c -I. -Ltarget/release -lripopt -Wl,-rpath,/home/bernalde/repos/ripopt/target/release -o /tmp/ripopt_c_hs035 -lm` — passed.
- `cc examples/c_example_with_options.c -I. -Ltarget/release -lripopt -Wl,-rpath,/home/bernalde/repos/ripopt/target/release -o /tmp/ripopt_c_example_with_options -lm` — passed.
- `/tmp/ripopt_c_api_test` — passed: output ended with `Test   : PASSED`.
- `/tmp/ripopt_c_rosenbrock` — passed: output ended with `Test   : PASSED`.
- `/tmp/ripopt_c_hs035` — passed: output ended with `Test        : PASSED`.
- `/tmp/ripopt_c_example_with_options` — passed: output ended with `=== Overall: ALL PASSED ===`.

## Notes

- No tests were skipped locally beyond the 25 tests skipped by the repository's nextest configuration.
- C example binaries were written to `/tmp` to avoid adding untracked files to the repository.

Closes #6
