### PR TITLE
Fix auxiliary full-space result semantics

### DIFF
--- a/src/auxiliary_preprocessing.rs
+++ b/src/auxiliary_preprocessing.rs
@@ -4,6 +4,7 @@
 //! implementation detail of `enable_preprocessing`; it must not expose a public
 //! decomposition or transform API.
 
+use crate::logging::rip_log;
 use crate::options::SolverOptions;
 use crate::problem::NlpProblem;
 use crate::result::{SolveResult, SolveStatus};
@@ -474,7 +475,24 @@ impl<'a> AuxiliaryReducedProblem<'a> {
         x_full
     }
 
+    #[cfg(test)]
     pub(crate) fn unmap_solution(&self, reduced: &SolveResult) -> SolveResult {
+        self.unmap_solution_impl(reduced, None)
+    }
+
+    pub(crate) fn unmap_solution_with_options(
+        &self,
+        reduced: &SolveResult,
+        options: &SolverOptions,
+    ) -> SolveResult {
+        self.unmap_solution_impl(reduced, Some(options))
+    }
+
+    fn unmap_solution_impl(
+        &self,
+        reduced: &SolveResult,
+        options: Option<&SolverOptions>,
+    ) -> SolveResult {
         let x_full = self.expand_x(&reduced.x);
 
         let mut constraint_multipliers = vec![0.0; self.m_orig];
@@ -492,6 +510,22 @@ impl<'a> AuxiliaryReducedProblem<'a> {
             }
             if reduced_idx < reduced.bound_multipliers_upper.len() {
                 bound_multipliers_upper[orig_idx] = reduced.bound_multipliers_upper[reduced_idx];
+            }
+        }
+
+        if let Err(reason) = self.reconstruct_removed_constraint_multipliers(
+            &x_full,
+            &mut constraint_multipliers,
+            &bound_multipliers_lower,
+            &bound_multipliers_upper,
+        ) {
+            if let Some(options) = options {
+                if options.print_level >= 5 {
+                    rip_log!(
+                        "ripopt: Auxiliary multiplier reconstruction skipped: {}",
+                        reason
+                    );
+                }
             }
         }
 
@@ -517,6 +551,207 @@ impl<'a> AuxiliaryReducedProblem<'a> {
             diagnostics: reduced.diagnostics.clone(),
         }
     }
+
+    fn reconstruct_removed_constraint_multipliers(
+        &self,
+        x_full: &[f64],
+        constraint_multipliers: &mut [f64],
+        bound_multipliers_lower: &[f64],
+        bound_multipliers_upper: &[f64],
+    ) -> Result<(), &'static str> {
+        let removed_rows = removed_indices(self.m_orig, &self.constr_map);
+        let removed_vars = removed_indices(self.n_orig, &self.var_map);
+        if removed_rows.is_empty() && removed_vars.is_empty() {
+            return Ok(());
+        }
+        if removed_rows.len() != removed_vars.len() {
+            return Err("removed auxiliary row/variable counts are not square");
+        }
+        if removed_rows.is_empty() {
+            return Ok(());
+        }
+        if self.removed_vars_have_bound_ambiguity(&removed_vars, x_full) {
+            return Err("removed auxiliary variable is active at a finite bound");
+        }
+
+        let mut grad = vec![0.0; self.n_orig];
+        if !self.inner.gradient(x_full, true, &mut grad) {
+            return Err("full gradient evaluation failed");
+        }
+
+        let (jac_rows, jac_cols) = self.inner.jacobian_structure();
+        if jac_rows.len() != jac_cols.len() {
+            return Err("Jacobian structure has mismatched row/column lengths");
+        }
+        let mut jac_vals = vec![0.0; jac_rows.len()];
+        if !self.inner.jacobian_values(x_full, true, &mut jac_vals) {
+            return Err("full Jacobian evaluation failed");
+        }
+
+        let row_pos = index_positions(self.m_orig, &removed_rows);
+        let var_pos = index_positions(self.n_orig, &removed_vars);
+        let dim = removed_rows.len();
+        let mut system = vec![0.0; dim * dim];
+        let mut rhs: Vec<f64> = removed_vars
+            .iter()
+            .map(|&var| {
+                -(grad[var] - bound_multipliers_lower[var] + bound_multipliers_upper[var])
+            })
+            .collect();
+
+        for (idx, (&row, &col)) in jac_rows.iter().zip(jac_cols.iter()).enumerate() {
+            if row >= self.m_orig || col >= self.n_orig {
+                continue;
+            }
+            let val = jac_vals[idx];
+            if !val.is_finite() {
+                return Err("Jacobian contains a non-finite value");
+            }
+            let Some(var_local) = var_pos[col] else {
+                continue;
+            };
+            if let Some(row_local) = row_pos[row] {
+                system[var_local * dim + row_local] += val;
+            } else {
+                rhs[var_local] -= val * constraint_multipliers[row];
+            }
+        }
+
+        let lambda = solve_dense_square_system(system, rhs, dim)?;
+        for (local, &row) in removed_rows.iter().enumerate() {
+            constraint_multipliers[row] = lambda[local];
+        }
+        Ok(())
+    }
+
+    fn removed_vars_have_bound_ambiguity(&self, removed_vars: &[usize], x_full: &[f64]) -> bool {
+        let mut x_l = vec![0.0; self.n_orig];
+        let mut x_u = vec![0.0; self.n_orig];
+        self.inner.bounds(&mut x_l, &mut x_u);
+        removed_vars.iter().any(|&var| {
+            let x = x_full[var];
+            let scale_l = x.abs().max(x_l[var].abs()).max(1.0);
+            let scale_u = x.abs().max(x_u[var].abs()).max(1.0);
+            (x_l[var].is_finite() && x <= x_l[var] + 1e-8 * scale_l)
+                || (x_u[var].is_finite() && x >= x_u[var] - 1e-8 * scale_u)
+        })
+    }
+}
+
+fn removed_indices(total: usize, kept: &[usize]) -> Vec<usize> {
+    let mut is_kept = vec![false; total];
+    for &idx in kept {
+        if idx < total {
+            is_kept[idx] = true;
+        }
+    }
+    (0..total).filter(|&idx| !is_kept[idx]).collect()
+}
+
+fn index_positions(total: usize, indices: &[usize]) -> Vec<Option<usize>> {
+    let mut positions = vec![None; total];
+    for (pos, &idx) in indices.iter().enumerate() {
+        if idx < total {
+            positions[idx] = Some(pos);
+        }
+    }
+    positions
+}
+
+fn solve_dense_square_system(
+    mut matrix: Vec<f64>,
+    mut rhs: Vec<f64>,
+    dim: usize,
+) -> Result<Vec<f64>, &'static str> {
+    if dim == 0 {
+        return Ok(Vec::new());
+    }
+    if matrix.len() != dim * dim || rhs.len() != dim {
+        return Err("dense system dimensions are inconsistent");
+    }
+    let max_abs = matrix
+        .iter()
+        .chain(rhs.iter())
+        .fold(0.0_f64, |acc, &value| acc.max(value.abs()));
+    if max_abs == 0.0 || !max_abs.is_finite() {
+        return Err("dense system is zero or non-finite");
+    }
+    if matrix.iter().chain(rhs.iter()).any(|value| !value.is_finite()) {
+        return Err("dense system contains a non-finite value");
+    }
+
+    let original_matrix = matrix.clone();
+    let original_rhs = rhs.clone();
+    let pivot_tol = (dim as f64) * max_abs * 1e-10;
+
+    for col in 0..dim {
+        let pivot_row = (col..dim)
+            .max_by(|&a, &b| {
+                matrix[a * dim + col]
+                    .abs()
+                    .partial_cmp(&matrix[b * dim + col].abs())
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .ok_or("dense system has no pivot row")?;
+        let pivot_abs = matrix[pivot_row * dim + col].abs();
+        if pivot_abs <= pivot_tol {
+            return Err("dense system is singular or ill-conditioned");
+        }
+        if pivot_row != col {
+            for j in col..dim {
+                matrix.swap(col * dim + j, pivot_row * dim + j);
+            }
+            rhs.swap(col, pivot_row);
+        }
+
+        let pivot = matrix[col * dim + col];
+        for row in (col + 1)..dim {
+            let factor = matrix[row * dim + col] / pivot;
+            matrix[row * dim + col] = 0.0;
+            for j in (col + 1)..dim {
+                matrix[row * dim + j] -= factor * matrix[col * dim + j];
+            }
+            rhs[row] -= factor * rhs[col];
+        }
+    }
+
+    let mut solution = vec![0.0; dim];
+    for i in (0..dim).rev() {
+        let mut sum = rhs[i];
+        for j in (i + 1)..dim {
+            sum -= matrix[i * dim + j] * solution[j];
+        }
+        let pivot = matrix[i * dim + i];
+        if pivot.abs() <= pivot_tol {
+            return Err("dense system is singular or ill-conditioned");
+        }
+        solution[i] = sum / pivot;
+    }
+    if solution.iter().any(|value| !value.is_finite()) {
+        return Err("dense system solution is non-finite");
+    }
+
+    let residual = dense_residual_inf(&original_matrix, &solution, &original_rhs, dim);
+    let rhs_norm = original_rhs
+        .iter()
+        .fold(0.0_f64, |acc, &value| acc.max(value.abs()));
+    if residual > 1e-8 * rhs_norm.max(1.0) {
+        return Err("dense system residual is too large");
+    }
+
+    Ok(solution)
+}
+
+fn dense_residual_inf(matrix: &[f64], x: &[f64], rhs: &[f64], dim: usize) -> f64 {
+    let mut residual: f64 = 0.0;
+    for row in 0..dim {
+        let mut ax = 0.0;
+        for col in 0..dim {
+            ax += matrix[row * dim + col] * x[col];
+        }
+        residual = residual.max((ax - rhs[row]).abs());
+    }
+    residual
 }
 
 impl NlpProblem for AuxiliaryReducedProblem<'_> {
@@ -2075,6 +2310,78 @@ mod tests {
         }
     }
 
+    struct KnownAuxMultiplierProblem {
+        bound_active_aux: bool,
+    }
+
+    impl NlpProblem for KnownAuxMultiplierProblem {
+        fn num_variables(&self) -> usize {
+            2
+        }
+
+        fn num_constraints(&self) -> usize {
+            1
+        }
+
+        fn bounds(&self, x_l: &mut [f64], x_u: &mut [f64]) {
+            x_l[0] = if self.bound_active_aux { 2.0 } else { f64::NEG_INFINITY };
+            x_u[0] = if self.bound_active_aux { 2.0 } else { f64::INFINITY };
+            x_l[1] = f64::NEG_INFINITY;
+            x_u[1] = f64::INFINITY;
+        }
+
+        fn constraint_bounds(&self, g_l: &mut [f64], g_u: &mut [f64]) {
+            g_l[0] = 0.0;
+            g_u[0] = 0.0;
+        }
+
+        fn initial_point(&self, x0: &mut [f64]) {
+            x0[0] = 2.0;
+            x0[1] = 5.0;
+        }
+
+        fn objective(&self, x: &[f64], _new_x: bool, obj: &mut f64) -> bool {
+            *obj = 3.0 * x[0] + (x[1] - 5.0) * (x[1] - 5.0);
+            true
+        }
+
+        fn gradient(&self, x: &[f64], _new_x: bool, grad: &mut [f64]) -> bool {
+            grad[0] = 3.0;
+            grad[1] = 2.0 * (x[1] - 5.0);
+            true
+        }
+
+        fn constraints(&self, x: &[f64], _new_x: bool, g: &mut [f64]) -> bool {
+            g[0] = x[0] - 2.0;
+            true
+        }
+
+        fn jacobian_structure(&self) -> (Vec<usize>, Vec<usize>) {
+            (vec![0], vec![0])
+        }
+
+        fn jacobian_values(&self, _x: &[f64], _new_x: bool, vals: &mut [f64]) -> bool {
+            vals[0] = 1.0;
+            true
+        }
+
+        fn hessian_structure(&self) -> (Vec<usize>, Vec<usize>) {
+            (vec![1], vec![1])
+        }
+
+        fn hessian_values(
+            &self,
+            _x: &[f64],
+            _new_x: bool,
+            obj_factor: f64,
+            _lambda: &[f64],
+            vals: &mut [f64],
+        ) -> bool {
+            vals[0] = 2.0 * obj_factor;
+            true
+        }
+    }
+
     struct RankDeficientAuxProblem;
 
     impl NlpProblem for RankDeficientAuxProblem {
@@ -2269,6 +2576,90 @@ mod tests {
         assert_eq!(full.bound_multipliers_upper, vec![0.3, 0.0, 0.4, 0.0]);
         assert_eq!(full.status, SolveStatus::Optimal);
         assert_eq!(full.iterations, 12);
+    }
+
+    #[test]
+    fn auxiliary_reduced_problem_reconstructs_removed_multiplier() {
+        let problem = KnownAuxMultiplierProblem {
+            bound_active_aux: false,
+        };
+        let candidates = vec![PresolveCandidate {
+            blocks: vec![EqualityBlock {
+                rows: vec![0],
+                vars: vec![0],
+            }],
+        }];
+        let reduced = AuxiliaryReducedProblem::new(&problem, &candidates, vec![2.0, 5.0])
+            .expect("auxiliary reduction");
+        let reduced_result = SolveResult {
+            x: vec![5.0],
+            objective: 0.0,
+            constraint_multipliers: vec![],
+            bound_multipliers_lower: vec![0.0],
+            bound_multipliers_upper: vec![0.0],
+            constraint_values: vec![],
+            status: SolveStatus::Optimal,
+            iterations: 1,
+            diagnostics: Default::default(),
+        };
+
+        let full = reduced.unmap_solution(&reduced_result);
+
+        assert_eq!(full.x, vec![2.0, 5.0]);
+        assert_eq!(full.constraint_values, vec![0.0]);
+        assert!(
+            (full.constraint_multipliers[0] + 3.0).abs() < 1e-10,
+            "lambda_aux={}, expected -3",
+            full.constraint_multipliers[0]
+        );
+    }
+
+    #[test]
+    fn auxiliary_reduced_problem_skips_multiplier_reconstruction_for_bound_active_auxiliary() {
+        let problem = KnownAuxMultiplierProblem {
+            bound_active_aux: true,
+        };
+        let candidates = vec![PresolveCandidate {
+            blocks: vec![EqualityBlock {
+                rows: vec![0],
+                vars: vec![0],
+            }],
+        }];
+        let reduced = AuxiliaryReducedProblem::new(&problem, &candidates, vec![2.0, 5.0])
+            .expect("auxiliary reduction");
+        let reduced_result = SolveResult {
+            x: vec![5.0],
+            objective: 0.0,
+            constraint_multipliers: vec![],
+            bound_multipliers_lower: vec![0.0],
+            bound_multipliers_upper: vec![0.0],
+            constraint_values: vec![],
+            status: SolveStatus::Optimal,
+            iterations: 1,
+            diagnostics: Default::default(),
+        };
+
+        let full = reduced.unmap_solution(&reduced_result);
+
+        assert_eq!(full.x, vec![2.0, 5.0]);
+        assert_eq!(full.constraint_values, vec![0.0]);
+        assert_eq!(
+            full.constraint_multipliers[0], 0.0,
+            "bound-active auxiliary variables should leave removed multipliers conservative"
+        );
+    }
+
+    #[test]
+    fn auxiliary_multiplier_reconstruction_rejects_singular_system() {
+        let matrix = vec![1.0, 2.0, 2.0, 4.0];
+        let rhs = vec![1.0, 2.0];
+
+        let result = solve_dense_square_system(matrix, rhs, 2);
+
+        assert!(
+            result.is_err(),
+            "singular multiplier systems should not be reconstructed"
+        );
     }
 
     #[test]

--- a/src/auxiliary_preprocessing.rs
+++ b/src/auxiliary_preprocessing.rs
@@ -594,9 +594,7 @@ impl<'a> AuxiliaryReducedProblem<'a> {
         let mut system = vec![0.0; dim * dim];
         let mut rhs: Vec<f64> = removed_vars
             .iter()
-            .map(|&var| {
-                -(grad[var] - bound_multipliers_lower[var] + bound_multipliers_upper[var])
-            })
+            .map(|&var| -(grad[var] - bound_multipliers_lower[var] + bound_multipliers_upper[var]))
             .collect();
 
         for (idx, (&row, &col)) in jac_rows.iter().zip(jac_cols.iter()).enumerate() {
@@ -669,20 +667,23 @@ fn solve_dense_square_system(
     if matrix.len() != dim * dim || rhs.len() != dim {
         return Err("dense system dimensions are inconsistent");
     }
-    let max_abs = matrix
-        .iter()
-        .chain(rhs.iter())
-        .fold(0.0_f64, |acc, &value| acc.max(value.abs()));
-    if max_abs == 0.0 || !max_abs.is_finite() {
-        return Err("dense system is zero or non-finite");
+    if matrix.iter().any(|value| !value.is_finite()) {
+        return Err("dense system matrix contains a non-finite value");
     }
-    if matrix.iter().chain(rhs.iter()).any(|value| !value.is_finite()) {
-        return Err("dense system contains a non-finite value");
+    if rhs.iter().any(|value| !value.is_finite()) {
+        return Err("dense system RHS contains a non-finite value");
+    }
+
+    let matrix_norm = matrix
+        .iter()
+        .fold(0.0_f64, |acc, &value| acc.max(value.abs()));
+    if matrix_norm == 0.0 {
+        return Err("dense system matrix is zero");
     }
 
     let original_matrix = matrix.clone();
     let original_rhs = rhs.clone();
-    let pivot_tol = (dim as f64) * max_abs * 1e-10;
+    let pivot_tol = (dim as f64) * matrix_norm * 1e-10;
 
     for col in 0..dim {
         let pivot_row = (col..dim)
@@ -905,11 +906,7 @@ fn auxiliary_block_jacobian_rank(
         return Ok(0);
     }
 
-    let x_block: Vec<_> = block_problem
-        .vars
-        .iter()
-        .map(|&var| fixed_x[var])
-        .collect();
+    let x_block: Vec<_> = block_problem.vars.iter().map(|&var| fixed_x[var]).collect();
     let mut jac_vals = vec![0.0; block_problem.jac_rows.len()];
     if !block_problem.jacobian_values(&x_block, true, &mut jac_vals) {
         return Err(AuxiliarySolveError::EvaluationFailed {
@@ -2312,6 +2309,7 @@ mod tests {
 
     struct KnownAuxMultiplierProblem {
         bound_active_aux: bool,
+        objective_slope: f64,
     }
 
     impl NlpProblem for KnownAuxMultiplierProblem {
@@ -2324,8 +2322,16 @@ mod tests {
         }
 
         fn bounds(&self, x_l: &mut [f64], x_u: &mut [f64]) {
-            x_l[0] = if self.bound_active_aux { 2.0 } else { f64::NEG_INFINITY };
-            x_u[0] = if self.bound_active_aux { 2.0 } else { f64::INFINITY };
+            x_l[0] = if self.bound_active_aux {
+                2.0
+            } else {
+                f64::NEG_INFINITY
+            };
+            x_u[0] = if self.bound_active_aux {
+                2.0
+            } else {
+                f64::INFINITY
+            };
             x_l[1] = f64::NEG_INFINITY;
             x_u[1] = f64::INFINITY;
         }
@@ -2341,12 +2347,12 @@ mod tests {
         }
 
         fn objective(&self, x: &[f64], _new_x: bool, obj: &mut f64) -> bool {
-            *obj = 3.0 * x[0] + (x[1] - 5.0) * (x[1] - 5.0);
+            *obj = self.objective_slope * x[0] + (x[1] - 5.0) * (x[1] - 5.0);
             true
         }
 
         fn gradient(&self, x: &[f64], _new_x: bool, grad: &mut [f64]) -> bool {
-            grad[0] = 3.0;
+            grad[0] = self.objective_slope;
             grad[1] = 2.0 * (x[1] - 5.0);
             true
         }
@@ -2582,6 +2588,7 @@ mod tests {
     fn auxiliary_reduced_problem_reconstructs_removed_multiplier() {
         let problem = KnownAuxMultiplierProblem {
             bound_active_aux: false,
+            objective_slope: 3.0,
         };
         let candidates = vec![PresolveCandidate {
             blocks: vec![EqualityBlock {
@@ -2615,9 +2622,46 @@ mod tests {
     }
 
     #[test]
+    fn auxiliary_reduced_problem_reconstructs_large_removed_multiplier() {
+        let problem = KnownAuxMultiplierProblem {
+            bound_active_aux: false,
+            objective_slope: 1.0e12,
+        };
+        let candidates = vec![PresolveCandidate {
+            blocks: vec![EqualityBlock {
+                rows: vec![0],
+                vars: vec![0],
+            }],
+        }];
+        let reduced = AuxiliaryReducedProblem::new(&problem, &candidates, vec![2.0, 5.0])
+            .expect("auxiliary reduction");
+        let reduced_result = SolveResult {
+            x: vec![5.0],
+            objective: 0.0,
+            constraint_multipliers: vec![],
+            bound_multipliers_lower: vec![0.0],
+            bound_multipliers_upper: vec![0.0],
+            constraint_values: vec![],
+            status: SolveStatus::Optimal,
+            iterations: 1,
+            diagnostics: Default::default(),
+        };
+
+        let full = reduced.unmap_solution(&reduced_result);
+
+        let expected = -1.0e12;
+        assert!(
+            (full.constraint_multipliers[0] - expected).abs() <= expected.abs() * 1e-12,
+            "lambda_aux={}, expected {expected}",
+            full.constraint_multipliers[0]
+        );
+    }
+
+    #[test]
     fn auxiliary_reduced_problem_skips_multiplier_reconstruction_for_bound_active_auxiliary() {
         let problem = KnownAuxMultiplierProblem {
             bound_active_aux: true,
+            objective_slope: 3.0,
         };
         let candidates = vec![PresolveCandidate {
             blocks: vec![EqualityBlock {

--- a/src/ipm.rs
+++ b/src/ipm.rs
@@ -1820,7 +1820,7 @@ fn try_auxiliary_preprocessed_solve<P: NlpProblem>(
 
     let nested_result = solve(&prep, &reduced_opts);
     let auxiliary_result = prep.unmap_solution(&nested_result);
-    let mut result = reduced.unmap_solution(&auxiliary_result);
+    let mut result = reduced.unmap_solution_with_options(&auxiliary_result, options);
     if matches!(result.status, SolveStatus::Optimal) {
         if let Some(validation) = validate_full_space_result(problem_dyn, &result, options) {
             result.objective = validation.objective;

--- a/tests/ipm_paths.rs
+++ b/tests/ipm_paths.rs
@@ -688,6 +688,11 @@ fn auxiliary_reduced_preprocessing_adopts_full_space_solution() {
     assert!(result.constraint_values[0].abs() < 1e-8);
     assert!((result.constraint_values[1] - 5.0).abs() < 1e-8);
     assert_eq!(result.constraint_multipliers.len(), 2);
+    assert!(
+        (result.constraint_multipliers[0] + 1.0).abs() < 1e-6,
+        "removed auxiliary row multiplier={}, expected -1",
+        result.constraint_multipliers[0]
+    );
     assert_eq!(result.bound_multipliers_lower.len(), 2);
     assert_eq!(result.bound_multipliers_upper.len(), 2);
 }


### PR DESCRIPTION
## Summary

- Reconstruct removed auxiliary equality-row multipliers when unmapping an auxiliary-reduced solve back to the original NLP.
- Keep reconstruction conservative: skip it for non-square, singular, non-finite, high-residual, or bound-active ambiguous auxiliary systems.
- Preserve full-space result semantics by keeping full objective/constraint recomputation and retained multiplier remapping intact.

## Tests run

- `cargo test auxiliary_reduced_problem_reconstructs_removed_multiplier` - passed
- `cargo test auxiliary_reduced_problem_skips_multiplier_reconstruction_for_bound_active_auxiliary` - passed
- `cargo test auxiliary_multiplier_reconstruction_rejects_singular_system` - passed
- `cargo test auxiliary_reduced_preprocessing_adopts_full_space_solution --test ipm_paths` - passed
- `cargo nextest run` - passed, 343 passed, 25 skipped
- `cargo test --doc` - passed, 1 passed
- `cargo build --release` - passed
- `make test-c` - passed, all C API examples passed

## Notes

- `cargo nextest run` reported the existing `.config/nextest.toml` unknown-key warning and existing unreachable-code warnings in limited-memory Hessian tests/examples; no new failures were introduced.

Closes #8
