### PR TITLE
Complete postsolve auxiliary recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ It implements a primal-dual interior point method with a barrier formulation, si
 - NLP scaling (gradient-based objective and constraint scaling)
 - Local infeasibility detection for inconsistent constraint systems
 - **Early stall detection**: bail out fast when stuck in early iterations to trigger fallbacks
-- **Preprocessing**: Automatic auxiliary equality-block reduction, fixed-variable elimination, redundant-constraint removal, and bound tightening from single-variable linear constraints
+- **Preprocessing**: Automatic auxiliary equality-block reduction/recovery, fixed-variable elimination, redundant-constraint removal, and bound tightening from single-variable linear constraints
 - **Near-linear constraint detection**: Automatically identifies linear constraints and skips their Hessian contribution
 - **Limited-memory Hessian approximation**: L-BFGS-in-IPM mode (`hessian_approximation_lbfgs`) replaces exact Hessian with L-BFGS curvature pairs, eliminating the need for second-derivative callbacks
 - **Multi-solver fallback architecture**: L-BFGS, Augmented Lagrangian, SQP, and explicit slack reformulation
@@ -460,8 +460,8 @@ Key options (all have Ipopt-matching defaults):
 | `warm_start`                    | false   | Enable warm-start initialization                           |
 | `constr_viol_tol`               | 1e-4    | Constraint violation tolerance                             |
 | `dual_inf_tol`                  | 1.0     | Dual infeasibility tolerance                               |
-| `enable_preprocessing`          | true    | Internal auxiliary equality solves, fixed variables, redundancies |
-| `auxiliary_tol`                 | 1e-8    | Accepted residual for internal auxiliary equality solves   |
+| `enable_preprocessing`          | true    | Internal auxiliary equality solves/recovery, fixed variables, redundancies |
+| `auxiliary_tol`                 | 1e-8    | Accepted residual for internal auxiliary equality solves/recovery |
 | `detect_linear_constraints`     | true    | Skip Hessian for linear constraints                        |
 | `enable_sqp_fallback`           | true    | SQP fallback for constrained problems                      |
 | `hessian_approximation_lbfgs`   | false   | Use L-BFGS Hessian approximation (no exact Hessian needed) |
@@ -622,7 +622,7 @@ Option-setting functions return `1` on success, `0` if the keyword is unknown. A
 | `constr_viol_tol`            | 1e-4    | Constraint violation tolerance                  |
 | `dual_inf_tol`               | 1.0     | Dual infeasibility tolerance                    |
 | `compl_inf_tol`              | 1e-4    | Complementarity tolerance                       |
-| `auxiliary_tol`              | 1e-8    | Residual tolerance for internal auxiliary equality solves |
+| `auxiliary_tol`              | 1e-8    | Residual tolerance for internal auxiliary equality solves/recovery |
 | `max_wall_time`              | 0.0     | Wall-clock time limit in seconds (0 = no limit) |
 | `warm_start_bound_push`      | 1e-3    | Warm-start bound push                           |
 | `warm_start_bound_frac`      | 1e-3    | Warm-start bound fraction                       |
@@ -654,7 +654,7 @@ Option-setting functions return `1` on success, `0` if the keyword is unknown. A
 | `enable_slack_fallback`         | `"yes"`      | `"yes"`, `"no"`               | Slack reformulation fallback                      |
 | `enable_lbfgs_fallback`         | `"yes"`      | `"yes"`, `"no"`               | L-BFGS fallback for unconstrained                 |
 | `enable_al_fallback`            | `"yes"`      | `"yes"`, `"no"`               | Augmented Lagrangian fallback                     |
-| `enable_preprocessing`          | `"yes"`      | `"yes"`, `"no"`               | Internal auxiliary equality solves, fixed vars, redundancies |
+| `enable_preprocessing`          | `"yes"`      | `"yes"`, `"no"`               | Internal auxiliary equality solves/recovery, fixed vars, redundancies |
 | `detect_linear_constraints`     | `"yes"`      | `"yes"`, `"no"`               | Skip Hessian for linear constraints               |
 | `enable_sqp_fallback`           | `"yes"`      | `"yes"`, `"no"`               | SQP fallback for constrained problems             |
 | `hessian_approximation`         | `"exact"`    | `"exact"`, `"limited-memory"` | Use L-BFGS Hessian approximation                  |
@@ -897,7 +897,7 @@ examples/
 
 Before solving, ripopt automatically analyzes the problem to reduce its size:
 
-1. **Auxiliary equality-system preprocessing**: Internal auxiliary equalities and variables may be solved and removed from the reduced problem
+1. **Auxiliary equality-system preprocessing/recovery**: Internal auxiliary equalities and variables may be solved before the main NLP or recovered after a reduced main solve when the removed variables are absent from the objective and inequalities
 2. **Fixed variable elimination**: Variables with `x_l == x_u` are removed and set to their fixed values in all evaluations
 3. **Redundant constraint removal**: Duplicate constraints (same Jacobian structure, values, and bounds) are eliminated
 4. **Bound tightening**: Single-variable linear constraints are used to tighten variable bounds

--- a/docs/src/options.md
+++ b/docs/src/options.md
@@ -116,8 +116,8 @@ let opts = SolverOptions {
 
 | Option | Default | Description |
 |---|---|---|
-| `enable_preprocessing` | `true` | Auxiliary equality-block preprocessing, fixed-variable elimination, and redundant-constraint removal |
-| `auxiliary_tol` | `1e-8` | Accepted residual for auxiliary preprocessing block solves |
+| `enable_preprocessing` | `true` | Auxiliary equality-block preprocessing/recovery, fixed-variable elimination, and redundant-constraint removal |
+| `auxiliary_tol` | `1e-8` | Accepted residual for auxiliary preprocessing/recovery block solves |
 | `detect_linear_constraints` | `true` | Skip Hessian for constraints with zero second derivatives |
 | `proactive_infeasibility_detection` | `false` | Early infeasibility detection during iterations |
 

--- a/src/auxiliary_preprocessing.rs
+++ b/src/auxiliary_preprocessing.rs
@@ -1208,6 +1208,52 @@ pub(crate) fn find_presolve_candidates(
         .collect()
 }
 
+#[allow(dead_code)]
+pub(crate) fn find_postsolve_candidates(
+    problem: &dyn NlpProblem,
+    tol: f64,
+) -> Vec<PresolveCandidate> {
+    let incidence = EqualityIncidence::from_problem(problem, tol);
+    if incidence.row_global.is_empty() {
+        return Vec::new();
+    }
+
+    let objective_independent = objective_independent_variables(problem, tol);
+    let inequality_coupled = variables_in_inequality_rows(problem, tol);
+    let selected_vars: Vec<_> = incidence
+        .var_adj_rows
+        .iter()
+        .enumerate()
+        .filter_map(|(var, rows)| {
+            (!rows.is_empty()
+                && objective_independent.get(var).copied().unwrap_or(false)
+                && !inequality_coupled.get(var).copied().unwrap_or(true))
+            .then_some(var)
+        })
+        .collect();
+    if selected_vars.is_empty() {
+        return Vec::new();
+    }
+
+    let mut selected_row = vec![false; incidence.row_adj_vars.len()];
+    for &var in &selected_vars {
+        for &row in &incidence.var_adj_rows[var] {
+            selected_row[row] = true;
+        }
+    }
+    let selected_rows: Vec<_> = selected_row
+        .iter()
+        .enumerate()
+        .filter_map(|(row, &selected)| selected.then_some(row))
+        .collect();
+
+    incidence
+        .connected_components(&selected_rows, &selected_vars)
+        .into_iter()
+        .filter_map(|component| postsolve_candidate_from_component(&incidence, component))
+        .collect()
+}
+
 fn presolve_candidate_from_component(
     incidence: &EqualityIncidence,
     component: EqualityBlock,
@@ -1225,6 +1271,26 @@ fn presolve_candidate_from_component(
     if !is_closed_equality_component(incidence, &local_rows, &component.vars) {
         return None;
     }
+
+    incidence
+        .block_triangular_decomposition(&local_rows, &component.vars)
+        .ok()
+        .map(|blocks| PresolveCandidate { blocks })
+}
+
+fn postsolve_candidate_from_component(
+    incidence: &EqualityIncidence,
+    component: EqualityBlock,
+) -> Option<PresolveCandidate> {
+    if component.rows.len() != component.vars.len() || component.rows.is_empty() {
+        return None;
+    }
+
+    let local_rows: Vec<_> = component
+        .rows
+        .iter()
+        .map(|&row| incidence.row_local_for_global[row])
+        .collect::<Option<_>>()?;
 
     incidence
         .block_triangular_decomposition(&local_rows, &component.vars)
@@ -1264,6 +1330,163 @@ fn is_closed_equality_component(
     })
 }
 
+fn variables_in_inequality_rows(problem: &dyn NlpProblem, tol: f64) -> Vec<bool> {
+    let n = problem.num_variables();
+    let m = problem.num_constraints();
+    let mut coupled = vec![false; n];
+    if n == 0 || m == 0 {
+        return coupled;
+    }
+
+    let mut g_l = vec![0.0; m];
+    let mut g_u = vec![0.0; m];
+    problem.constraint_bounds(&mut g_l, &mut g_u);
+
+    let (jac_rows, jac_cols) = problem.jacobian_structure();
+    for (&row, &col) in jac_rows.iter().zip(jac_cols.iter()) {
+        if row >= m || col >= n {
+            continue;
+        }
+        if !is_equality_bound(g_l[row], g_u[row], tol) {
+            coupled[col] = true;
+        }
+    }
+    coupled
+}
+
+fn objective_independent_variables(problem: &dyn NlpProblem, tol: f64) -> Vec<bool> {
+    let n = problem.num_variables();
+    let mut independent = vec![false; n];
+    if n == 0 {
+        return independent;
+    }
+
+    let mut x_l = vec![0.0; n];
+    let mut x_u = vec![0.0; n];
+    problem.bounds(&mut x_l, &mut x_u);
+
+    let mut x0 = vec![0.0; n];
+    problem.initial_point(&mut x0);
+
+    let mut obj0 = 0.0;
+    if !problem.objective(&x0, true, &mut obj0) || !obj0.is_finite() {
+        return independent;
+    }
+
+    let mut grad0 = vec![0.0; n];
+    if !problem.gradient(&x0, true, &mut grad0) {
+        return independent;
+    }
+
+    let grad_all = perturb_all_variables(&x0, &x_l, &x_u).and_then(|x_probe| {
+        let mut grad = vec![0.0; n];
+        problem
+            .gradient(&x_probe, true, &mut grad)
+            .then_some(grad)
+    });
+
+    let tol = tol.max(1e-10);
+    for var in 0..n {
+        if !near_zero(grad0[var], tol) {
+            continue;
+        }
+        if grad_all
+            .as_ref()
+            .is_some_and(|grad| !near_zero(grad[var], tol))
+        {
+            continue;
+        }
+
+        let Some(x_var) = perturb_single_variable(&x0, &x_l, &x_u, var) else {
+            continue;
+        };
+        let mut obj_var = 0.0;
+        if !problem.objective(&x_var, true, &mut obj_var) || !obj_var.is_finite() {
+            continue;
+        }
+        let obj_scale = obj0.abs().max(obj_var.abs()).max(1.0);
+        if (obj_var - obj0).abs() > tol * obj_scale {
+            continue;
+        }
+
+        let mut grad_var = vec![0.0; n];
+        if !problem.gradient(&x_var, true, &mut grad_var) || !near_zero(grad_var[var], tol) {
+            continue;
+        }
+
+        independent[var] = true;
+    }
+    independent
+}
+
+fn near_zero(value: f64, tol: f64) -> bool {
+    value.is_finite() && value.abs() <= tol
+}
+
+fn perturb_all_variables(x: &[f64], x_l: &[f64], x_u: &[f64]) -> Option<Vec<f64>> {
+    let mut out = x.to_vec();
+    let mut changed = false;
+    for i in 0..x.len() {
+        if let Some(value) = perturbed_value(x[i], x_l[i], x_u[i]) {
+            out[i] = value;
+            changed = true;
+        }
+    }
+    changed.then_some(out)
+}
+
+fn perturb_single_variable(
+    x: &[f64],
+    x_l: &[f64],
+    x_u: &[f64],
+    var: usize,
+) -> Option<Vec<f64>> {
+    let value = perturbed_value(x[var], x_l[var], x_u[var])?;
+    let mut out = x.to_vec();
+    out[var] = value;
+    Some(out)
+}
+
+fn perturbed_value(x: f64, lower: f64, upper: f64) -> Option<f64> {
+    if !x.is_finite() {
+        return None;
+    }
+    let scale = x.abs().max(1.0);
+    let min_disp = 1e-4 * scale;
+    let delta = 1.0 + 0.1 * x.abs();
+
+    for candidate in [x + delta, x - delta] {
+        if candidate_is_usable(candidate, x, lower, upper, min_disp) {
+            return Some(candidate);
+        }
+    }
+
+    if lower.is_finite() && upper.is_finite() && upper > lower {
+        for candidate in [
+            0.5 * (lower + upper),
+            lower + 0.25 * (upper - lower),
+            upper - 0.25 * (upper - lower),
+        ] {
+            if candidate_is_usable(candidate, x, lower, upper, min_disp) {
+                return Some(candidate);
+            }
+        }
+    }
+
+    None
+}
+
+fn candidate_is_usable(candidate: f64, x: f64, lower: f64, upper: f64, min_disp: f64) -> bool {
+    candidate.is_finite()
+        && (!lower.is_finite() || candidate >= lower)
+        && (!upper.is_finite() || candidate <= upper)
+        && (candidate - x).abs() >= min_disp
+}
+
+fn is_equality_bound(lower: f64, upper: f64, tol: f64) -> bool {
+    lower.is_finite() && upper.is_finite() && (lower - upper).abs() <= tol
+}
+
 #[derive(Debug, Clone, Copy)]
 enum BipartiteNode {
     Row(usize),
@@ -1285,7 +1508,7 @@ impl EqualityIncidence {
         let mut row_global = Vec::new();
         let mut row_local_for_global = vec![None; m_orig];
         for i in 0..m_orig {
-            if g_l[i].is_finite() && g_u[i].is_finite() && (g_l[i] - g_u[i]).abs() <= tol {
+            if is_equality_bound(g_l[i], g_u[i], tol) {
                 row_local_for_global[i] = Some(row_global.len());
                 row_global.push(i);
             }
@@ -4471,6 +4694,59 @@ mod tests {
                 }],
             }]
         );
+    }
+
+    #[test]
+    fn find_postsolve_candidates_allows_recovery_row_with_main_variable() {
+        let bounds = equality_bounds(1);
+        let problem = graph_problem_with_objective(2, &bounds, &[(0, 0), (0, 1)], &[0]);
+
+        let candidates = find_postsolve_candidates(&problem, TOL);
+
+        assert_eq!(
+            candidates,
+            vec![PresolveCandidate {
+                blocks: vec![EqualityBlock {
+                    rows: vec![0],
+                    vars: vec![1],
+                }],
+            }]
+        );
+    }
+
+    #[test]
+    fn find_postsolve_candidates_rejects_objective_dependent_variable() {
+        let bounds = equality_bounds(1);
+        let problem = graph_problem_with_objective(2, &bounds, &[(0, 1)], &[1]);
+
+        let candidates = find_postsolve_candidates(&problem, TOL);
+
+        assert!(candidates.is_empty());
+    }
+
+    #[test]
+    fn find_postsolve_candidates_rejects_inequality_coupled_variable() {
+        let problem = graph_problem_with_objective(
+            2,
+            &[(0.0, 0.0), (0.0, 1.0)],
+            &[(0, 0), (0, 1), (1, 1)],
+            &[0],
+        );
+
+        let candidates = find_postsolve_candidates(&problem, TOL);
+
+        assert!(candidates.is_empty());
+    }
+
+    #[test]
+    fn find_postsolve_candidates_rejects_ambiguous_feasibility_system() {
+        let bounds = equality_bounds(2);
+        let problem =
+            graph_problem_with_objective(2, &bounds, &[(0, 0), (0, 1), (1, 0), (1, 1)], &[0]);
+
+        let candidates = find_postsolve_candidates(&problem, TOL);
+
+        assert!(candidates.is_empty());
     }
 
     #[test]

--- a/src/bin/ripopt_ampl.rs
+++ b/src/bin/ripopt_ampl.rs
@@ -140,7 +140,7 @@ fn print_help() {
     println!("    constr_viol_tol=<float>              Constraint violation tolerance [1e-4]");
     println!("    dual_inf_tol=<float>                 Dual infeasibility tolerance [1.0]");
     println!("    compl_inf_tol=<float>                Complementarity tolerance [1e-4]");
-    println!("    auxiliary_tol=<float>                Residual tolerance for internal auxiliary equality solves [1e-8]");
+    println!("    auxiliary_tol=<float>                Residual tolerance for internal auxiliary equality solves/recovery [1e-8]");
     println!();
     println!("  Barrier Parameter");
     println!("    mu_init=<float>                      Initial barrier parameter [0.1]");
@@ -199,7 +199,7 @@ fn print_help() {
     println!("    enable_lbfgs_hessian_fallback=<bool> Retry with L-BFGS Hessian [yes]");
     println!();
     println!("  Preprocessing & Diagnostics");
-    println!("    enable_preprocessing=<bool>          Internal auxiliary equality solves, fixed vars, redundancies [yes]");
+    println!("    enable_preprocessing=<bool>          Internal auxiliary equality solves/recovery, fixed vars, redundancies [yes]");
     println!("    proactive_infeasibility_detection=<bool> Early infeasibility detection [no]");
     println!("    print_level=<int>                    Verbosity: 0=silent, 5=verbose [5]");
     println!("    early_stall_timeout=<float>          Max seconds for first 3 iters (0=off) [120.0]");

--- a/src/ipm.rs
+++ b/src/ipm.rs
@@ -1706,6 +1706,43 @@ fn auxiliary_preprocessing_options(
     Some(attempt_opts)
 }
 
+fn auxiliary_reduced_solve_options(
+    options: &SolverOptions,
+    preprocess_opts: &SolverOptions,
+    reduced: &crate::auxiliary_preprocessing::AuxiliaryReducedProblem<'_>,
+    prep: &crate::preprocessing::PreprocessedProblem<'_>,
+    solve_start: Instant,
+) -> Option<SolverOptions> {
+    let mut reduced_opts = preprocess_opts.clone();
+    reduced_opts.enable_preprocessing = false;
+    reduced_opts.warm_start = false;
+    reduced_opts.warm_start_y = None;
+    reduced_opts.warm_start_z_l = None;
+    reduced_opts.warm_start_z_u = None;
+    let aux_x_scaling = options
+        .user_x_scaling
+        .as_ref()
+        .and_then(|scaling| reduced.reduced_x_scaling(scaling));
+    reduced_opts.user_x_scaling = aux_x_scaling
+        .as_ref()
+        .and_then(|scaling| prep.reduced_x_scaling(scaling));
+    let aux_g_scaling = options
+        .user_g_scaling
+        .as_ref()
+        .and_then(|scaling| reduced.reduced_g_scaling(scaling));
+    reduced_opts.user_g_scaling = aux_g_scaling
+        .as_ref()
+        .and_then(|scaling| prep.reduced_g_scaling(scaling));
+    if preprocess_opts.max_wall_time > 0.0 {
+        let remaining = preprocess_opts.max_wall_time - solve_start.elapsed().as_secs_f64();
+        if remaining <= 0.1 {
+            return None;
+        }
+        reduced_opts.max_wall_time = remaining;
+    }
+    Some(reduced_opts)
+}
+
 /// Auxiliary preprocessing attempt: solve block-triangular equality
 /// subsystems first, remove the solved auxiliary variables and equality rows,
 /// then run the existing preprocessing wrapper on the auxiliary-reduced
@@ -1790,33 +1827,11 @@ fn try_auxiliary_preprocessed_solve<P: NlpProblem>(
         );
     }
 
-    let mut reduced_opts = preprocess_opts.clone();
-    reduced_opts.enable_preprocessing = false;
-    reduced_opts.warm_start = false;
-    reduced_opts.warm_start_y = None;
-    reduced_opts.warm_start_z_l = None;
-    reduced_opts.warm_start_z_u = None;
-    let aux_x_scaling = options
-        .user_x_scaling
-        .as_ref()
-        .and_then(|scaling| reduced.reduced_x_scaling(scaling));
-    reduced_opts.user_x_scaling = aux_x_scaling
-        .as_ref()
-        .and_then(|scaling| prep.reduced_x_scaling(scaling));
-    let aux_g_scaling = options
-        .user_g_scaling
-        .as_ref()
-        .and_then(|scaling| reduced.reduced_g_scaling(scaling));
-    reduced_opts.user_g_scaling = aux_g_scaling
-        .as_ref()
-        .and_then(|scaling| prep.reduced_g_scaling(scaling));
-    if preprocess_opts.max_wall_time > 0.0 {
-        let remaining = preprocess_opts.max_wall_time - solve_start.elapsed().as_secs_f64();
-        if remaining <= 0.1 {
-            return AuxiliaryPreprocessAttempt::Failed;
-        }
-        reduced_opts.max_wall_time = remaining;
-    }
+    let Some(reduced_opts) =
+        auxiliary_reduced_solve_options(options, &preprocess_opts, &reduced, &prep, solve_start)
+    else {
+        return AuxiliaryPreprocessAttempt::Failed;
+    };
 
     let nested_result = solve(&prep, &reduced_opts);
     let auxiliary_result = prep.unmap_solution(&nested_result);
@@ -1837,6 +1852,134 @@ fn try_auxiliary_preprocessed_solve<P: NlpProblem>(
         rip_log!(
             "ripopt: Auxiliary-reduced solve failed ({:?}), retrying without auxiliary preprocessing",
             result.status,
+        );
+    }
+    AuxiliaryPreprocessAttempt::Failed
+}
+
+/// Auxiliary postsolve attempt: remove objective/inequality-independent
+/// equality recovery variables before the main solve, solve the reduced main
+/// NLP, then recover the removed variables from the equality subsystem in the
+/// context of the reduced solution.
+fn try_auxiliary_postsolve_solve<P: NlpProblem>(
+    problem: &P,
+    options: &SolverOptions,
+    solve_start: Instant,
+) -> AuxiliaryPreprocessAttempt {
+    let problem_dyn = problem as &dyn NlpProblem;
+    let candidates =
+        crate::auxiliary_preprocessing::find_postsolve_candidates(problem_dyn, options.auxiliary_tol);
+    if candidates.is_empty() {
+        return AuxiliaryPreprocessAttempt::NoCandidates;
+    }
+
+    let Some(preprocess_opts) = auxiliary_preprocessing_options(options, solve_start) else {
+        return AuxiliaryPreprocessAttempt::Failed;
+    };
+
+    let mut x_context = vec![0.0; problem.num_variables()];
+    problem.initial_point(&mut x_context);
+    let reduced =
+        match crate::auxiliary_preprocessing::AuxiliaryReducedProblem::new(problem_dyn, &candidates, x_context.clone())
+        {
+            Ok(reduced) if reduced.did_reduce() => reduced,
+            Ok(_) => return AuxiliaryPreprocessAttempt::Failed,
+            Err(err) => {
+                if options.print_level >= 5 {
+                    rip_log!("ripopt: Auxiliary postsolve skipped after reduction failure: {:?}", err);
+                }
+                return AuxiliaryPreprocessAttempt::Failed;
+            }
+        };
+
+    if options.print_level >= 5 {
+        rip_log!(
+            "ripopt: Auxiliary postsolve reduced problem: {} recovery vars, {} recovery constraints ({}x{} -> {}x{})",
+            reduced.num_fixed(),
+            reduced.num_removed_constraints(),
+            problem.num_variables(),
+            problem.num_constraints(),
+            reduced.num_variables(),
+            reduced.num_constraints(),
+        );
+    }
+
+    let prep = crate::preprocessing::PreprocessedProblem::new(&reduced as &dyn NlpProblem, options.bound_push);
+    if options.print_level >= 5 && prep.did_reduce() {
+        rip_log!(
+            "ripopt: Auxiliary postsolve nested preprocessing reduced problem: {} fixed vars, {} redundant constraints ({}x{} -> {}x{})",
+            prep.num_fixed(), prep.num_redundant(),
+            reduced.num_variables(), reduced.num_constraints(),
+            prep.num_variables(), prep.num_constraints(),
+        );
+    }
+
+    let Some(reduced_opts) =
+        auxiliary_reduced_solve_options(options, &preprocess_opts, &reduced, &prep, solve_start)
+    else {
+        return AuxiliaryPreprocessAttempt::Failed;
+    };
+
+    let nested_result = solve(&prep, &reduced_opts);
+    let auxiliary_result = prep.unmap_solution(&nested_result);
+    if !matches!(auxiliary_result.status, SolveStatus::Optimal) {
+        if options.print_level >= 5 {
+            rip_log!(
+                "ripopt: Auxiliary-postsolve reduced solve failed ({:?}), retrying without auxiliary postsolve",
+                auxiliary_result.status,
+            );
+        }
+        return AuxiliaryPreprocessAttempt::Failed;
+    }
+
+    let partial = reduced.unmap_solution_with_options(&auxiliary_result, options);
+    x_context = partial.x;
+    let outcome = match crate::auxiliary_preprocessing::solve_auxiliary_blocks_from(
+        problem_dyn,
+        &candidates,
+        &preprocess_opts,
+        solve_start,
+        &mut x_context,
+    ) {
+        Ok(outcome) if outcome.blocks_solved > 0 => outcome,
+        Ok(_) => return AuxiliaryPreprocessAttempt::Failed,
+        Err(err) => {
+            if options.print_level >= 5 {
+                rip_log!("ripopt: Auxiliary postsolve recovery failed: {:?}", err);
+            }
+            return AuxiliaryPreprocessAttempt::Failed;
+        }
+    };
+
+    if options.print_level >= 5 {
+        rip_log!(
+            "ripopt: Auxiliary postsolve recovered {} block(s), max residual {:.2e}",
+            outcome.blocks_solved,
+            outcome.max_residual,
+        );
+    }
+
+    let recovered_reduced =
+        match crate::auxiliary_preprocessing::AuxiliaryReducedProblem::new(problem_dyn, &candidates, outcome.x)
+        {
+            Ok(reduced) => reduced,
+            Err(err) => {
+                if options.print_level >= 5 {
+                    rip_log!("ripopt: Auxiliary postsolve skipped after recovery validation failure: {:?}", err);
+                }
+                return AuxiliaryPreprocessAttempt::Failed;
+            }
+        };
+    let mut result = recovered_reduced.unmap_solution_with_options(&auxiliary_result, options);
+    if let Some(validation) = validate_full_space_result(problem_dyn, &result, options) {
+        result.objective = validation.objective;
+        result.constraint_values = validation.constraints;
+        result.diagnostics.final_primal_inf = validation.primal_inf;
+        return AuxiliaryPreprocessAttempt::Solved(result);
+    }
+    if options.print_level >= 5 {
+        rip_log!(
+            "ripopt: Auxiliary-postsolve result validation failed, retrying without auxiliary postsolve"
         );
     }
     AuxiliaryPreprocessAttempt::Failed
@@ -1880,8 +2023,9 @@ fn try_standard_preprocessed_solve<P: NlpProblem>(
     None
 }
 
-/// Run preprocessing (auxiliary equality-block reduction first, otherwise
-/// fixed-variable and redundant-constraint elimination)
+/// Run preprocessing (presolve auxiliary equality-block reduction, postsolve
+/// auxiliary equality recovery, then fixed-variable and redundant-constraint
+/// elimination)
 /// and, if it reduces the problem, recursively `solve` the smaller problem
 /// then unmap the solution. Returns `Some(result)` only when the
 /// preprocessed solve reaches `Optimal`; otherwise returns `None` so the
@@ -1899,10 +2043,15 @@ fn try_preprocessed_solve<P: NlpProblem>(
         return None;
     }
 
-    match try_auxiliary_preprocessed_solve(problem, options, solve_start) {
+    if let AuxiliaryPreprocessAttempt::Solved(result) =
+        try_auxiliary_preprocessed_solve(problem, options, solve_start)
+    {
+        return Some(result);
+    }
+
+    match try_auxiliary_postsolve_solve(problem, options, solve_start) {
         AuxiliaryPreprocessAttempt::Solved(result) => Some(result),
-        AuxiliaryPreprocessAttempt::Failed => None,
-        AuxiliaryPreprocessAttempt::NoCandidates => {
+        AuxiliaryPreprocessAttempt::Failed | AuxiliaryPreprocessAttempt::NoCandidates => {
             try_standard_preprocessed_solve(problem, options, solve_start)
         }
     }

--- a/src/ipm.rs
+++ b/src/ipm.rs
@@ -1641,6 +1641,7 @@ struct FullSpaceValidation {
     objective: f64,
     constraints: Vec<f64>,
     primal_inf: f64,
+    dual_inf: f64,
 }
 
 fn validate_full_space_result(
@@ -1683,10 +1684,56 @@ fn validate_full_space_result(
         return None;
     }
 
+    let mut grad = vec![0.0; n];
+    if !problem.gradient(&result.x, true, &mut grad) || grad.iter().any(|value| !value.is_finite())
+    {
+        return None;
+    }
+
+    let (jac_rows, jac_cols) = problem.jacobian_structure();
+    if jac_rows.len() != jac_cols.len() {
+        return None;
+    }
+    let mut jac_vals = vec![0.0; jac_rows.len()];
+    if !problem.jacobian_values(&result.x, true, &mut jac_vals)
+        || jac_vals.iter().any(|value| !value.is_finite())
+    {
+        return None;
+    }
+    for (&row, &col) in jac_rows.iter().zip(jac_cols.iter()) {
+        if row >= m || col >= n {
+            return None;
+        }
+    }
+    if result
+        .constraint_multipliers
+        .iter()
+        .chain(result.bound_multipliers_lower.iter())
+        .chain(result.bound_multipliers_upper.iter())
+        .any(|value| !value.is_finite())
+    {
+        return None;
+    }
+
+    let dual_inf = convergence::dual_infeasibility(
+        &grad,
+        &jac_rows,
+        &jac_cols,
+        &jac_vals,
+        &result.constraint_multipliers,
+        &result.bound_multipliers_lower,
+        &result.bound_multipliers_upper,
+        n,
+    );
+    if !dual_inf.is_finite() || dual_inf > options.dual_inf_tol {
+        return None;
+    }
+
     Some(FullSpaceValidation {
         objective,
         constraints,
         primal_inf,
+        dual_inf,
     })
 }
 
@@ -1841,6 +1888,7 @@ fn try_auxiliary_preprocessed_solve<P: NlpProblem>(
             result.objective = validation.objective;
             result.constraint_values = validation.constraints;
             result.diagnostics.final_primal_inf = validation.primal_inf;
+            result.diagnostics.final_dual_inf = validation.dual_inf;
             return AuxiliaryPreprocessAttempt::Solved(result);
         }
         if options.print_level >= 5 {
@@ -1975,6 +2023,7 @@ fn try_auxiliary_postsolve_solve<P: NlpProblem>(
         result.objective = validation.objective;
         result.constraint_values = validation.constraints;
         result.diagnostics.final_primal_inf = validation.primal_inf;
+        result.diagnostics.final_dual_inf = validation.dual_inf;
         return AuxiliaryPreprocessAttempt::Solved(result);
     }
     if options.print_level >= 5 {
@@ -10900,10 +10949,90 @@ mod tests {
         SolveResult {
             x: vec![x],
             objective: f64::NAN,
-            constraint_multipliers: vec![0.0],
+            constraint_multipliers: vec![-2.0 * x],
             bound_multipliers_lower: vec![0.0],
             bound_multipliers_upper: vec![0.0],
             constraint_values: vec![f64::NAN],
+            status: SolveStatus::Optimal,
+            iterations: 0,
+            diagnostics: SolverDiagnostics::default(),
+        }
+    }
+
+    struct FalsePositivePostsolveProblem;
+
+    impl NlpProblem for FalsePositivePostsolveProblem {
+        fn num_variables(&self) -> usize { 2 }
+        fn num_constraints(&self) -> usize { 1 }
+
+        fn bounds(&self, x_l: &mut [f64], x_u: &mut [f64]) {
+            x_l.fill(f64::NEG_INFINITY);
+            x_u.fill(f64::INFINITY);
+        }
+
+        fn constraint_bounds(&self, g_l: &mut [f64], g_u: &mut [f64]) {
+            g_l[0] = 0.0;
+            g_u[0] = 0.0;
+        }
+
+        fn initial_point(&self, x0: &mut [f64]) {
+            x0[0] = 0.5;
+            x0[1] = 0.0;
+        }
+
+        fn objective(&self, x: &[f64], _new_x: bool, obj: &mut f64) -> bool {
+            *obj = (x[0] - 2.0) * (x[0] - 2.0)
+                + 100.0 * x[1] * x[1] * (x[1] - 1.0) * (x[1] - 1.0);
+            true
+        }
+
+        fn gradient(&self, x: &[f64], _new_x: bool, grad: &mut [f64]) -> bool {
+            grad[0] = 2.0 * (x[0] - 2.0);
+            grad[1] = 200.0 * x[1] * (x[1] - 1.0) * (2.0 * x[1] - 1.0);
+            true
+        }
+
+        fn constraints(&self, x: &[f64], _new_x: bool, g: &mut [f64]) -> bool {
+            g[0] = x[1] - x[0];
+            true
+        }
+
+        fn jacobian_structure(&self) -> (Vec<usize>, Vec<usize>) {
+            (vec![0, 0], vec![0, 1])
+        }
+
+        fn jacobian_values(&self, _x: &[f64], _new_x: bool, vals: &mut [f64]) -> bool {
+            vals[0] = -1.0;
+            vals[1] = 1.0;
+            true
+        }
+
+        fn hessian_structure(&self) -> (Vec<usize>, Vec<usize>) {
+            (vec![0, 1], vec![0, 1])
+        }
+
+        fn hessian_values(
+            &self,
+            x: &[f64],
+            _new_x: bool,
+            obj_factor: f64,
+            _lambda: &[f64],
+            vals: &mut [f64],
+        ) -> bool {
+            vals[0] = 2.0 * obj_factor;
+            vals[1] = obj_factor * (1200.0 * x[1] * x[1] - 1200.0 * x[1] + 200.0);
+            true
+        }
+    }
+
+    fn false_positive_postsolve_result() -> SolveResult {
+        SolveResult {
+            x: vec![2.0, 2.0],
+            objective: 400.0,
+            constraint_multipliers: vec![-1200.0],
+            bound_multipliers_lower: vec![0.0, 0.0],
+            bound_multipliers_upper: vec![0.0, 0.0],
+            constraint_values: vec![0.0],
             status: SolveStatus::Optimal,
             iterations: 0,
             diagnostics: SolverDiagnostics::default(),
@@ -11046,6 +11175,24 @@ mod tests {
         assert_eq!(validation.constraints.len(), 1);
         assert!((validation.constraints[0] - 1.00005).abs() < 1e-12);
         assert!((validation.primal_inf - 5e-5).abs() < 1e-12);
+        assert!(validation.dual_inf < 1e-12);
+    }
+
+    #[test]
+    fn full_space_validation_rejects_postsolve_objective_probe_false_positive() {
+        let problem = FalsePositivePostsolveProblem;
+        let options = SolverOptions {
+            dual_inf_tol: 1.0,
+            ..SolverOptions::default()
+        };
+        let result = false_positive_postsolve_result();
+
+        let validation = validate_full_space_result(&problem, &result, &options);
+
+        assert!(
+            validation.is_none(),
+            "postsolve candidates with large full-space stationarity residual must fall back"
+        );
     }
 
     #[test]

--- a/tests/ipm_paths.rs
+++ b/tests/ipm_paths.rs
@@ -1107,6 +1107,112 @@ fn preprocessing_disabled_bypasses_auxiliary_preprocessing_in_solve() {
     assert!((result.x[1] - 2.0).abs() < 1e-5, "x={:?}", result.x);
 }
 
+struct PostsolveRecoveryProblem {
+    full_constraint_hessian_seen: Cell<bool>,
+}
+
+impl NlpProblem for PostsolveRecoveryProblem {
+    fn num_variables(&self) -> usize { 3 }
+    fn num_constraints(&self) -> usize { 1 }
+
+    fn bounds(&self, x_l: &mut [f64], x_u: &mut [f64]) {
+        x_l[0] = f64::NEG_INFINITY;
+        x_u[0] = f64::INFINITY;
+        x_l[1] = f64::NEG_INFINITY;
+        x_u[1] = f64::INFINITY;
+        x_l[2] = 4.0;
+        x_u[2] = 4.0;
+    }
+
+    fn constraint_bounds(&self, g_l: &mut [f64], g_u: &mut [f64]) {
+        g_l[0] = 0.0;
+        g_u[0] = 0.0;
+    }
+
+    fn initial_point(&self, x0: &mut [f64]) {
+        x0[0] = 0.5;
+        x0[1] = 0.0;
+        x0[2] = 4.0;
+    }
+
+    fn objective(&self, x: &[f64], _new_x: bool, obj: &mut f64) -> bool {
+        *obj = (x[0] - 3.0) * (x[0] - 3.0) + (x[2] - 4.0) * (x[2] - 4.0);
+        true
+    }
+
+    fn gradient(&self, x: &[f64], _new_x: bool, grad: &mut [f64]) -> bool {
+        grad[0] = 2.0 * (x[0] - 3.0);
+        grad[1] = 0.0;
+        grad[2] = 2.0 * (x[2] - 4.0);
+        true
+    }
+
+    fn constraints(&self, x: &[f64], _new_x: bool, g: &mut [f64]) -> bool {
+        g[0] = x[1] - x[0] * x[0];
+        true
+    }
+
+    fn jacobian_structure(&self) -> (Vec<usize>, Vec<usize>) {
+        (vec![0, 0], vec![0, 1])
+    }
+
+    fn jacobian_values(&self, x: &[f64], _new_x: bool, vals: &mut [f64]) -> bool {
+        vals[0] = -2.0 * x[0];
+        vals[1] = 1.0;
+        true
+    }
+
+    fn hessian_structure(&self) -> (Vec<usize>, Vec<usize>) {
+        (vec![0, 2], vec![0, 2])
+    }
+
+    fn hessian_values(
+        &self,
+        _x: &[f64],
+        _new_x: bool,
+        obj_factor: f64,
+        lambda: &[f64],
+        vals: &mut [f64],
+    ) -> bool {
+        if lambda.first().copied().unwrap_or(0.0).abs() > 1e-12 {
+            self.full_constraint_hessian_seen.set(true);
+        }
+        vals[0] = 2.0 * obj_factor - 2.0 * lambda.first().copied().unwrap_or(0.0);
+        vals[1] = 2.0 * obj_factor;
+        true
+    }
+}
+
+#[test]
+fn auxiliary_postsolve_recovers_equality_variable_after_reduced_solve() {
+    let problem = PostsolveRecoveryProblem {
+        full_constraint_hessian_seen: Cell::new(false),
+    };
+    let options = SolverOptions {
+        print_level: 0,
+        enable_preprocessing: true,
+        enable_al_fallback: false,
+        enable_sqp_fallback: false,
+        max_iter: 200,
+        tol: 1e-8,
+        ..SolverOptions::default()
+    };
+
+    let result = ripopt::solve(&problem, &options);
+
+    assert_eq!(result.status, SolveStatus::Optimal, "result={result:?}");
+    assert!((result.x[0] - 3.0).abs() < 1e-6, "x={:?}", result.x);
+    assert!((result.x[1] - 9.0).abs() < 1e-6, "x={:?}", result.x);
+    assert!((result.x[2] - 4.0).abs() < 1e-12, "x={:?}", result.x);
+    assert!(result.constraint_values[0].abs() < 1e-8);
+    assert_eq!(result.constraint_multipliers.len(), 1);
+    assert_eq!(result.bound_multipliers_lower.len(), 3);
+    assert!(
+        !problem.full_constraint_hessian_seen.get(),
+        "postsolve path should remove the recovery row from the main reduced solve"
+    );
+}
+
 #[derive(Debug)]
 struct AuxiliaryGateMetrics {
     status: SolveStatus,


### PR DESCRIPTION
## Summary

- Add an internal postsolve auxiliary-equality recovery path under `enable_preprocessing`.
- Detect recovery variables that are absent from objective probes and inequality rows, solve the reduced main NLP, recover removed equality variables afterward, reconstruct full-space results, and validate the returned solution.
- Keep the existing presolve auxiliary path and standard fixed-variable/redundant-row preprocessing internal, with user-visible docs updated for preprocessing/recovery behavior.

## Tests run

- `cargo test find_postsolve_candidates --lib` - passed, 4 tests.
- `cargo test --test ipm_paths auxiliary_postsolve_recovers_equality_variable_after_reduced_solve` - passed, 1 test.
- `cargo test auxiliary_preprocessing --lib` - passed, 67 tests.
- `cargo test --test ipm_paths` - passed, 17 tests.
- `cargo test --test nl_integration nl_issue_23_executable_incidence_fixtures_compare_preprocessing` - passed, 1 test.
- `cargo nextest run` - passed, 373 tests run, 373 passed, 25 skipped. Existing unreachable-code warnings were emitted from L-BFGS tests/examples.
- `cargo test --doc` - passed, 1 doctest.
- `cargo build --release` - passed.
- `make test-c` - passed, all C API examples passed.

## Notes about tests not run

- `cargo fmt --check` was attempted but is not usable as a local gate in this checkout because it reports large pre-existing rustfmt drift across generated, benchmark, and test files unrelated to this PR. No formatting changes were applied.
- Python regeneration of local incidence examples was not run; the committed incidence `.nl` fixtures were exercised through the Rust NL integration test above, so no local Python environment was used.

Closes #28
