### PR TITLE
Refactor preprocessing reduction frames

### DIFF
--- a/src/auxiliary_preprocessing.rs
+++ b/src/auxiliary_preprocessing.rs
@@ -7,6 +7,7 @@
 use crate::logging::rip_log;
 use crate::options::SolverOptions;
 use crate::problem::NlpProblem;
+use crate::reduction_frame::{ReductionFrame, RemovedMultiplierRecovery};
 use crate::result::{SolveResult, SolveStatus};
 use std::cmp::Reverse;
 use std::collections::{BinaryHeap, VecDeque};
@@ -599,6 +600,7 @@ impl NlpProblem for AuxiliaryBlockProblem<'_> {
 #[allow(dead_code)]
 pub(crate) struct AuxiliaryReducedProblem<'a> {
     inner: &'a dyn NlpProblem,
+    frame: ReductionFrame,
     n_orig: usize,
     m_orig: usize,
     fixed_x: Vec<f64>,
@@ -712,8 +714,18 @@ impl<'a> AuxiliaryReducedProblem<'a> {
             }
         }
 
+        let frame = ReductionFrame::new(
+            n_orig,
+            m_orig,
+            var_map.clone(),
+            constr_map.clone(),
+            fixed_x.clone(),
+            RemovedMultiplierRecovery::AuxiliaryStationarity,
+        );
+
         Ok(Self {
             inner,
+            frame,
             n_orig,
             m_orig,
             fixed_x,
@@ -731,317 +743,37 @@ impl<'a> AuxiliaryReducedProblem<'a> {
     }
 
     pub(crate) fn did_reduce(&self) -> bool {
-        self.var_map.len() < self.n_orig || self.constr_map.len() < self.m_orig
+        self.frame.did_reduce()
     }
 
     pub(crate) fn num_fixed(&self) -> usize {
-        self.n_orig - self.var_map.len()
+        self.frame.num_removed_vars()
     }
 
     pub(crate) fn num_removed_constraints(&self) -> usize {
-        self.m_orig - self.constr_map.len()
+        self.frame.num_removed_rows()
     }
 
     pub(crate) fn reduced_x_scaling(&self, scaling: &[f64]) -> Option<Vec<f64>> {
-        if scaling.len() != self.n_orig {
-            return None;
-        }
-        Some(self.var_map.iter().map(|&orig| scaling[orig]).collect())
+        self.frame.reduced_x_scaling(scaling)
     }
 
     pub(crate) fn reduced_g_scaling(&self, scaling: &[f64]) -> Option<Vec<f64>> {
-        if scaling.len() != self.m_orig {
-            return None;
-        }
-        Some(self.constr_map.iter().map(|&orig| scaling[orig]).collect())
+        self.frame.reduced_g_scaling(scaling)
+    }
+
+    pub(crate) fn reduction_frame(&self) -> &ReductionFrame {
+        &self.frame
     }
 
     fn expand_x(&self, x_reduced: &[f64]) -> Vec<f64> {
-        let mut x_full = self.fixed_x.clone();
-        for (reduced, &orig) in self.var_map.iter().enumerate() {
-            x_full[orig] = x_reduced[reduced];
-        }
-        x_full
+        self.frame.expand_x(x_reduced)
     }
 
     #[cfg(test)]
     pub(crate) fn unmap_solution(&self, reduced: &SolveResult) -> SolveResult {
-        self.unmap_solution_impl(reduced, None)
+        self.frame.unmap_solution(self.inner, reduced)
     }
-
-    pub(crate) fn unmap_solution_with_options(
-        &self,
-        reduced: &SolveResult,
-        options: &SolverOptions,
-    ) -> SolveResult {
-        self.unmap_solution_impl(reduced, Some(options))
-    }
-
-    fn unmap_solution_impl(
-        &self,
-        reduced: &SolveResult,
-        options: Option<&SolverOptions>,
-    ) -> SolveResult {
-        let x_full = self.expand_x(&reduced.x);
-
-        let mut constraint_multipliers = vec![0.0; self.m_orig];
-        for (reduced_idx, &orig_idx) in self.constr_map.iter().enumerate() {
-            if reduced_idx < reduced.constraint_multipliers.len() {
-                constraint_multipliers[orig_idx] = reduced.constraint_multipliers[reduced_idx];
-            }
-        }
-
-        let mut bound_multipliers_lower = vec![0.0; self.n_orig];
-        let mut bound_multipliers_upper = vec![0.0; self.n_orig];
-        for (reduced_idx, &orig_idx) in self.var_map.iter().enumerate() {
-            if reduced_idx < reduced.bound_multipliers_lower.len() {
-                bound_multipliers_lower[orig_idx] = reduced.bound_multipliers_lower[reduced_idx];
-            }
-            if reduced_idx < reduced.bound_multipliers_upper.len() {
-                bound_multipliers_upper[orig_idx] = reduced.bound_multipliers_upper[reduced_idx];
-            }
-        }
-
-        if let Err(reason) = self.reconstruct_removed_constraint_multipliers(
-            &x_full,
-            &mut constraint_multipliers,
-            &bound_multipliers_lower,
-            &bound_multipliers_upper,
-        ) {
-            if let Some(options) = options {
-                if options.print_level >= 5 {
-                    rip_log!(
-                        "ripopt: Auxiliary multiplier reconstruction skipped: {}",
-                        reason
-                    );
-                }
-            }
-        }
-
-        let mut objective = reduced.objective;
-        let _ = self.inner.objective(&x_full, true, &mut objective);
-
-        let mut constraint_values = vec![0.0; self.m_orig];
-        if self.m_orig > 0 {
-            let _ = self
-                .inner
-                .constraints(&x_full, true, &mut constraint_values);
-        }
-
-        SolveResult {
-            x: x_full,
-            objective,
-            constraint_multipliers,
-            bound_multipliers_lower,
-            bound_multipliers_upper,
-            constraint_values,
-            status: reduced.status,
-            iterations: reduced.iterations,
-            diagnostics: reduced.diagnostics.clone(),
-        }
-    }
-
-    fn reconstruct_removed_constraint_multipliers(
-        &self,
-        x_full: &[f64],
-        constraint_multipliers: &mut [f64],
-        bound_multipliers_lower: &[f64],
-        bound_multipliers_upper: &[f64],
-    ) -> Result<(), &'static str> {
-        let removed_rows = removed_indices(self.m_orig, &self.constr_map);
-        let removed_vars = removed_indices(self.n_orig, &self.var_map);
-        if removed_rows.is_empty() && removed_vars.is_empty() {
-            return Ok(());
-        }
-        if removed_rows.len() != removed_vars.len() {
-            return Err("removed auxiliary row/variable counts are not square");
-        }
-        if removed_rows.is_empty() {
-            return Ok(());
-        }
-        if self.removed_vars_have_bound_ambiguity(&removed_vars, x_full) {
-            return Err("removed auxiliary variable is active at a finite bound");
-        }
-
-        let mut grad = vec![0.0; self.n_orig];
-        if !self.inner.gradient(x_full, true, &mut grad) {
-            return Err("full gradient evaluation failed");
-        }
-
-        let (jac_rows, jac_cols) = self.inner.jacobian_structure();
-        if jac_rows.len() != jac_cols.len() {
-            return Err("Jacobian structure has mismatched row/column lengths");
-        }
-        let mut jac_vals = vec![0.0; jac_rows.len()];
-        if !self.inner.jacobian_values(x_full, true, &mut jac_vals) {
-            return Err("full Jacobian evaluation failed");
-        }
-
-        let row_pos = index_positions(self.m_orig, &removed_rows);
-        let var_pos = index_positions(self.n_orig, &removed_vars);
-        let dim = removed_rows.len();
-        let mut system = vec![0.0; dim * dim];
-        let mut rhs: Vec<f64> = removed_vars
-            .iter()
-            .map(|&var| -(grad[var] - bound_multipliers_lower[var] + bound_multipliers_upper[var]))
-            .collect();
-
-        for (idx, (&row, &col)) in jac_rows.iter().zip(jac_cols.iter()).enumerate() {
-            if row >= self.m_orig || col >= self.n_orig {
-                continue;
-            }
-            let val = jac_vals[idx];
-            if !val.is_finite() {
-                return Err("Jacobian contains a non-finite value");
-            }
-            let Some(var_local) = var_pos[col] else {
-                continue;
-            };
-            if let Some(row_local) = row_pos[row] {
-                system[var_local * dim + row_local] += val;
-            } else {
-                rhs[var_local] -= val * constraint_multipliers[row];
-            }
-        }
-
-        let lambda = solve_dense_square_system(system, rhs, dim)?;
-        for (local, &row) in removed_rows.iter().enumerate() {
-            constraint_multipliers[row] = lambda[local];
-        }
-        Ok(())
-    }
-
-    fn removed_vars_have_bound_ambiguity(&self, removed_vars: &[usize], x_full: &[f64]) -> bool {
-        let mut x_l = vec![0.0; self.n_orig];
-        let mut x_u = vec![0.0; self.n_orig];
-        self.inner.bounds(&mut x_l, &mut x_u);
-        removed_vars.iter().any(|&var| {
-            let x = x_full[var];
-            let scale_l = x.abs().max(x_l[var].abs()).max(1.0);
-            let scale_u = x.abs().max(x_u[var].abs()).max(1.0);
-            (x_l[var].is_finite() && x <= x_l[var] + 1e-8 * scale_l)
-                || (x_u[var].is_finite() && x >= x_u[var] - 1e-8 * scale_u)
-        })
-    }
-}
-
-fn removed_indices(total: usize, kept: &[usize]) -> Vec<usize> {
-    let mut is_kept = vec![false; total];
-    for &idx in kept {
-        if idx < total {
-            is_kept[idx] = true;
-        }
-    }
-    (0..total).filter(|&idx| !is_kept[idx]).collect()
-}
-
-fn index_positions(total: usize, indices: &[usize]) -> Vec<Option<usize>> {
-    let mut positions = vec![None; total];
-    for (pos, &idx) in indices.iter().enumerate() {
-        if idx < total {
-            positions[idx] = Some(pos);
-        }
-    }
-    positions
-}
-
-fn solve_dense_square_system(
-    mut matrix: Vec<f64>,
-    mut rhs: Vec<f64>,
-    dim: usize,
-) -> Result<Vec<f64>, &'static str> {
-    if dim == 0 {
-        return Ok(Vec::new());
-    }
-    if matrix.len() != dim * dim || rhs.len() != dim {
-        return Err("dense system dimensions are inconsistent");
-    }
-    if matrix.iter().any(|value| !value.is_finite()) {
-        return Err("dense system matrix contains a non-finite value");
-    }
-    if rhs.iter().any(|value| !value.is_finite()) {
-        return Err("dense system RHS contains a non-finite value");
-    }
-
-    let matrix_norm = matrix
-        .iter()
-        .fold(0.0_f64, |acc, &value| acc.max(value.abs()));
-    if matrix_norm == 0.0 {
-        return Err("dense system matrix is zero");
-    }
-
-    let original_matrix = matrix.clone();
-    let original_rhs = rhs.clone();
-    let pivot_tol = (dim as f64) * matrix_norm * 1e-10;
-
-    for col in 0..dim {
-        let pivot_row = (col..dim)
-            .max_by(|&a, &b| {
-                matrix[a * dim + col]
-                    .abs()
-                    .partial_cmp(&matrix[b * dim + col].abs())
-                    .unwrap_or(std::cmp::Ordering::Equal)
-            })
-            .ok_or("dense system has no pivot row")?;
-        let pivot_abs = matrix[pivot_row * dim + col].abs();
-        if pivot_abs <= pivot_tol {
-            return Err("dense system is singular or ill-conditioned");
-        }
-        if pivot_row != col {
-            for j in col..dim {
-                matrix.swap(col * dim + j, pivot_row * dim + j);
-            }
-            rhs.swap(col, pivot_row);
-        }
-
-        let pivot = matrix[col * dim + col];
-        for row in (col + 1)..dim {
-            let factor = matrix[row * dim + col] / pivot;
-            matrix[row * dim + col] = 0.0;
-            for j in (col + 1)..dim {
-                matrix[row * dim + j] -= factor * matrix[col * dim + j];
-            }
-            rhs[row] -= factor * rhs[col];
-        }
-    }
-
-    let mut solution = vec![0.0; dim];
-    for i in (0..dim).rev() {
-        let mut sum = rhs[i];
-        for j in (i + 1)..dim {
-            sum -= matrix[i * dim + j] * solution[j];
-        }
-        let pivot = matrix[i * dim + i];
-        if pivot.abs() <= pivot_tol {
-            return Err("dense system is singular or ill-conditioned");
-        }
-        solution[i] = sum / pivot;
-    }
-    if solution.iter().any(|value| !value.is_finite()) {
-        return Err("dense system solution is non-finite");
-    }
-
-    let residual = dense_residual_inf(&original_matrix, &solution, &original_rhs, dim);
-    let rhs_norm = original_rhs
-        .iter()
-        .fold(0.0_f64, |acc, &value| acc.max(value.abs()));
-    if residual > 1e-8 * rhs_norm.max(1.0) {
-        return Err("dense system residual is too large");
-    }
-
-    Ok(solution)
-}
-
-fn dense_residual_inf(matrix: &[f64], x: &[f64], rhs: &[f64], dim: usize) -> f64 {
-    let mut residual: f64 = 0.0;
-    for row in 0..dim {
-        let mut ax = 0.0;
-        for col in 0..dim {
-            ax += matrix[row * dim + col] * x[col];
-        }
-        residual = residual.max((ax - rhs[row]).abs());
-    }
-    residual
 }
 
 impl NlpProblem for AuxiliaryReducedProblem<'_> {
@@ -2617,6 +2349,8 @@ fn topologically_order_blocks(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::preprocessing::PreprocessedProblem;
+    use crate::reduction_frame::{solve_dense_square_system, ReductionStack};
 
     const TOL: f64 = 1e-10;
 
@@ -3193,6 +2927,86 @@ mod tests {
         }
     }
 
+    struct ComposedReductionProblem;
+
+    impl NlpProblem for ComposedReductionProblem {
+        fn num_variables(&self) -> usize {
+            3
+        }
+
+        fn num_constraints(&self) -> usize {
+            3
+        }
+
+        fn bounds(&self, x_l: &mut [f64], x_u: &mut [f64]) {
+            x_l[0] = -10.0;
+            x_u[0] = 10.0;
+            x_l[1] = f64::NEG_INFINITY;
+            x_u[1] = f64::INFINITY;
+            x_l[2] = 5.0;
+            x_u[2] = 5.0;
+        }
+
+        fn constraint_bounds(&self, g_l: &mut [f64], g_u: &mut [f64]) {
+            g_l[0] = 0.0;
+            g_u[0] = 0.0;
+            g_l[1] = 6.0;
+            g_u[1] = 6.0;
+            g_l[2] = 6.0;
+            g_u[2] = 6.0;
+        }
+
+        fn initial_point(&self, x0: &mut [f64]) {
+            x0[0] = 0.0;
+            x0[1] = 2.0;
+            x0[2] = 5.0;
+        }
+
+        fn objective(&self, x: &[f64], _new_x: bool, obj: &mut f64) -> bool {
+            *obj = 0.5 * x[0] * x[0] + 3.0 * x[1];
+            true
+        }
+
+        fn gradient(&self, x: &[f64], _new_x: bool, grad: &mut [f64]) -> bool {
+            grad[0] = x[0];
+            grad[1] = 3.0;
+            grad[2] = 0.0;
+            true
+        }
+
+        fn constraints(&self, x: &[f64], _new_x: bool, g: &mut [f64]) -> bool {
+            g[0] = x[1] - 2.0;
+            g[1] = x[0] + x[2];
+            g[2] = x[0] + x[2];
+            true
+        }
+
+        fn jacobian_structure(&self) -> (Vec<usize>, Vec<usize>) {
+            (vec![0, 1, 1, 2, 2], vec![1, 0, 2, 0, 2])
+        }
+
+        fn jacobian_values(&self, _x: &[f64], _new_x: bool, vals: &mut [f64]) -> bool {
+            vals.fill(1.0);
+            true
+        }
+
+        fn hessian_structure(&self) -> (Vec<usize>, Vec<usize>) {
+            (vec![0], vec![0])
+        }
+
+        fn hessian_values(
+            &self,
+            _x: &[f64],
+            _new_x: bool,
+            obj_factor: f64,
+            _lambda: &[f64],
+            vals: &mut [f64],
+        ) -> bool {
+            vals[0] = obj_factor;
+            true
+        }
+    }
+
     struct RankDeficientAuxProblem;
 
     impl NlpProblem for RankDeficientAuxProblem {
@@ -3387,6 +3201,52 @@ mod tests {
         assert_eq!(full.bound_multipliers_upper, vec![0.3, 0.0, 0.4, 0.0]);
         assert_eq!(full.status, SolveStatus::Optimal);
         assert_eq!(full.iterations, 12);
+    }
+
+    #[test]
+    fn reduction_stack_composes_auxiliary_then_standard_unmapping() {
+        let problem = ComposedReductionProblem;
+        let candidates = vec![PresolveCandidate {
+            blocks: vec![EqualityBlock {
+                rows: vec![0],
+                vars: vec![1],
+            }],
+        }];
+        let auxiliary = AuxiliaryReducedProblem::new(&problem, &candidates, vec![0.0, 2.0, 5.0])
+            .expect("auxiliary reduction");
+        let standard = PreprocessedProblem::new(&auxiliary as &dyn NlpProblem, 1e-2);
+
+        assert_eq!(auxiliary.var_map, vec![0, 2]);
+        assert_eq!(auxiliary.constr_map, vec![1, 2]);
+        assert!(standard.did_reduce());
+        assert_eq!(standard.num_fixed(), 1);
+        assert_eq!(standard.num_redundant(), 1);
+
+        let nested_result = SolveResult {
+            x: vec![1.0],
+            objective: -1.0,
+            constraint_multipliers: vec![7.0],
+            bound_multipliers_lower: vec![0.1],
+            bound_multipliers_upper: vec![0.3],
+            constraint_values: vec![6.0],
+            status: SolveStatus::Optimal,
+            iterations: 4,
+            diagnostics: Default::default(),
+        };
+
+        let full = ReductionStack::new()
+            .push(standard.reduction_frame(), &auxiliary as &dyn NlpProblem)
+            .push(auxiliary.reduction_frame(), &problem as &dyn NlpProblem)
+            .unmap_solution_with_options(&nested_result, None);
+
+        assert_eq!(full.x, vec![1.0, 2.0, 5.0]);
+        assert!((full.objective - 6.5).abs() < 1e-12);
+        assert_eq!(full.constraint_values, vec![0.0, 6.0, 6.0]);
+        assert_eq!(full.constraint_multipliers, vec![-3.0, 7.0, 0.0]);
+        assert_eq!(full.bound_multipliers_lower, vec![0.1, 0.0, 0.0]);
+        assert_eq!(full.bound_multipliers_upper, vec![0.3, 0.0, 0.0]);
+        assert_eq!(full.status, SolveStatus::Optimal);
+        assert_eq!(full.iterations, 4);
     }
 
     #[test]

--- a/src/ipm.rs
+++ b/src/ipm.rs
@@ -1927,8 +1927,10 @@ fn try_auxiliary_preprocessed_solve<P: NlpProblem>(
     };
 
     let nested_result = solve(&prep, &reduced_opts);
-    let auxiliary_result = prep.unmap_solution(&nested_result);
-    let mut result = reduced.unmap_solution_with_options(&auxiliary_result, options);
+    let stack = crate::reduction_frame::ReductionStack::new()
+        .push(prep.reduction_frame(), &reduced as &dyn NlpProblem)
+        .push(reduced.reduction_frame(), problem_dyn);
+    let mut result = stack.unmap_solution_with_options(&nested_result, Some(options));
     if matches!(result.status, SolveStatus::Optimal) {
         if let Some(validation) = validate_full_space_result(problem_dyn, &result, options) {
             result.objective = validation.objective;
@@ -2064,7 +2066,9 @@ fn try_auxiliary_postsolve_solve<P: NlpProblem>(
     };
 
     let nested_result = solve(&prep, &reduced_opts);
-    let auxiliary_result = prep.unmap_solution(&nested_result);
+    let standard_stack = crate::reduction_frame::ReductionStack::new()
+        .push(prep.reduction_frame(), &reduced as &dyn NlpProblem);
+    let auxiliary_result = standard_stack.unmap_solution_with_options(&nested_result, Some(options));
     if !matches!(auxiliary_result.status, SolveStatus::Optimal) {
         diagnostics.reject_global(
             crate::auxiliary_preprocessing::AuxiliaryRejectionReason::AuxiliarySolveFailure {
@@ -2082,7 +2086,10 @@ fn try_auxiliary_postsolve_solve<P: NlpProblem>(
         return AuxiliaryPreprocessAttempt::Failed;
     }
 
-    let partial = reduced.unmap_solution_with_options(&auxiliary_result, options);
+    let partial_stack = crate::reduction_frame::ReductionStack::new()
+        .push(prep.reduction_frame(), &reduced as &dyn NlpProblem)
+        .push(reduced.reduction_frame(), problem_dyn);
+    let partial = partial_stack.unmap_solution_with_options(&nested_result, Some(options));
     x_context = partial.x;
     let outcome = match crate::auxiliary_preprocessing::solve_auxiliary_blocks_from(
         problem_dyn,
@@ -2133,7 +2140,10 @@ fn try_auxiliary_postsolve_solve<P: NlpProblem>(
                 return AuxiliaryPreprocessAttempt::Failed;
             }
         };
-    let mut result = recovered_reduced.unmap_solution_with_options(&auxiliary_result, options);
+    let recovered_stack = crate::reduction_frame::ReductionStack::new()
+        .push(prep.reduction_frame(), &reduced as &dyn NlpProblem)
+        .push(recovered_reduced.reduction_frame(), problem_dyn);
+    let mut result = recovered_stack.unmap_solution_with_options(&nested_result, Some(options));
     if let Some(validation) = validate_full_space_result(problem_dyn, &result, options) {
         result.objective = validation.objective;
         result.constraint_values = validation.constraints;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,7 @@ pub mod nl;
 pub mod options;
 pub mod preprocessing;
 pub mod problem;
+pub(crate) mod reduction_frame;
 pub mod restoration;
 pub mod restoration_nlp;
 pub mod result;

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -6,6 +6,7 @@
 //! - Variable bounds tightened from single-variable linear constraints
 
 use crate::problem::NlpProblem;
+use crate::reduction_frame::{ReductionFrame, RemovedMultiplierRecovery};
 use crate::result::SolveResult;
 
 /// NLP problem wrapper that eliminates fixed variables and redundant constraints.
@@ -14,14 +15,13 @@ use crate::result::SolveResult;
 /// when called from inside the generic `solve<P>`.
 pub struct PreprocessedProblem<'a> {
     inner: &'a dyn NlpProblem,
+    frame: ReductionFrame,
     n_orig: usize,
     m_orig: usize,
     /// Reduced variable index -> original variable index
     var_map: Vec<usize>,
     /// Reduced constraint index -> original constraint index
     constr_map: Vec<usize>,
-    /// Full-size vector with fixed values filled in (NaN for free variables)
-    fixed_values: Vec<f64>,
     /// Original variable index -> reduced variable index (None if fixed)
     _orig_to_reduced_var: Vec<Option<usize>>,
     /// Remapped Jacobian sparsity
@@ -396,13 +396,22 @@ impl<'a> PreprocessedProblem<'a> {
             }
         }
 
+        let frame = ReductionFrame::new(
+            n,
+            m,
+            var_map.clone(),
+            constr_map.clone(),
+            fixed_values.clone(),
+            RemovedMultiplierRecovery::None,
+        );
+
         PreprocessedProblem {
             inner,
+            frame,
             n_orig: n,
             m_orig: m,
             var_map,
             constr_map,
-            fixed_values,
             _orig_to_reduced_var: orig_to_reduced_var,
             jac_rows: jac_rows_new,
             jac_cols: jac_cols_new,
@@ -431,74 +440,25 @@ impl<'a> PreprocessedProblem<'a> {
     }
 
     pub(crate) fn reduced_x_scaling(&self, scaling: &[f64]) -> Option<Vec<f64>> {
-        if scaling.len() != self.n_orig {
-            return None;
-        }
-        Some(self.var_map.iter().map(|&orig| scaling[orig]).collect())
+        self.frame.reduced_x_scaling(scaling)
     }
 
     pub(crate) fn reduced_g_scaling(&self, scaling: &[f64]) -> Option<Vec<f64>> {
-        if scaling.len() != self.m_orig {
-            return None;
-        }
-        Some(self.constr_map.iter().map(|&orig| scaling[orig]).collect())
+        self.frame.reduced_g_scaling(scaling)
+    }
+
+    pub(crate) fn reduction_frame(&self) -> &ReductionFrame {
+        &self.frame
     }
 
     /// Build a full-size x vector from a reduced x vector.
     fn expand_x(&self, x_reduced: &[f64]) -> Vec<f64> {
-        let mut x_full = self.fixed_values.clone();
-        for (red_i, &orig_i) in self.var_map.iter().enumerate() {
-            x_full[orig_i] = x_reduced[red_i];
-        }
-        x_full
+        self.frame.expand_x(x_reduced)
     }
 
     /// Map the solution from the reduced problem back to the original problem dimensions.
     pub fn unmap_solution(&self, reduced: &SolveResult) -> SolveResult {
-        let n = self.n_orig;
-        let m = self.m_orig;
-
-        // Expand x
-        let x_full = self.expand_x(&reduced.x);
-
-        // Expand bound multipliers
-        let mut z_l_full = vec![0.0; n];
-        let mut z_u_full = vec![0.0; n];
-        for (red_i, &orig_i) in self.var_map.iter().enumerate() {
-            z_l_full[orig_i] = reduced.bound_multipliers_lower[red_i];
-            z_u_full[orig_i] = reduced.bound_multipliers_upper[red_i];
-        }
-
-        // Expand constraint multipliers and values
-        let mut y_full = vec![0.0; m];
-        let mut g_full = vec![0.0; m];
-
-        // Evaluate original constraints at the full solution
-        if m > 0 {
-            let _ = self.inner.constraints(&x_full, true, &mut g_full);
-        }
-
-        for (red_i, &orig_i) in self.constr_map.iter().enumerate() {
-            if red_i < reduced.constraint_multipliers.len() {
-                y_full[orig_i] = reduced.constraint_multipliers[red_i];
-            }
-        }
-
-        // Recompute objective at full solution
-        let mut obj = 0.0;
-        let _ = self.inner.objective(&x_full, true, &mut obj);
-
-        SolveResult {
-            x: x_full,
-            objective: obj,
-            constraint_multipliers: y_full,
-            bound_multipliers_lower: z_l_full,
-            bound_multipliers_upper: z_u_full,
-            constraint_values: g_full,
-            status: reduced.status,
-            iterations: reduced.iterations,
-            diagnostics: reduced.diagnostics.clone(),
-        }
+        self.frame.unmap_solution(self.inner, reduced)
     }
 }
 

--- a/src/reduction_frame.rs
+++ b/src/reduction_frame.rs
@@ -1,0 +1,408 @@
+//! Internal preprocessing reduction frames.
+//!
+//! Reduction frames are intentionally crate-private. They carry the mapping
+//! needed to transfer a reduced solve result back to the problem that produced
+//! the reduced view, without advertising a public transform-stack API.
+
+use crate::logging::rip_log;
+use crate::options::SolverOptions;
+use crate::problem::NlpProblem;
+use crate::result::SolveResult;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RemovedMultiplierRecovery {
+    None,
+    AuxiliaryStationarity,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct ReductionFrame {
+    n_orig: usize,
+    m_orig: usize,
+    /// Reduced variable index -> original variable index.
+    var_map: Vec<usize>,
+    /// Reduced row index -> original row index.
+    row_map: Vec<usize>,
+    /// Original-space values for variables not present in the reduced problem.
+    fixed_values: Vec<f64>,
+    multiplier_recovery: RemovedMultiplierRecovery,
+}
+
+impl ReductionFrame {
+    pub(crate) fn new(
+        n_orig: usize,
+        m_orig: usize,
+        var_map: Vec<usize>,
+        row_map: Vec<usize>,
+        fixed_values: Vec<f64>,
+        multiplier_recovery: RemovedMultiplierRecovery,
+    ) -> Self {
+        debug_assert_eq!(fixed_values.len(), n_orig);
+        Self {
+            n_orig,
+            m_orig,
+            var_map,
+            row_map,
+            fixed_values,
+            multiplier_recovery,
+        }
+    }
+
+    pub(crate) fn did_reduce(&self) -> bool {
+        self.var_map.len() < self.n_orig || self.row_map.len() < self.m_orig
+    }
+
+    pub(crate) fn num_removed_vars(&self) -> usize {
+        self.n_orig - self.var_map.len()
+    }
+
+    pub(crate) fn num_removed_rows(&self) -> usize {
+        self.m_orig - self.row_map.len()
+    }
+
+    pub(crate) fn removed_vars(&self) -> Vec<usize> {
+        removed_indices(self.n_orig, &self.var_map)
+    }
+
+    pub(crate) fn removed_rows(&self) -> Vec<usize> {
+        removed_indices(self.m_orig, &self.row_map)
+    }
+
+    pub(crate) fn reduced_x_scaling(&self, scaling: &[f64]) -> Option<Vec<f64>> {
+        if scaling.len() != self.n_orig {
+            return None;
+        }
+        Some(self.var_map.iter().map(|&orig| scaling[orig]).collect())
+    }
+
+    pub(crate) fn reduced_g_scaling(&self, scaling: &[f64]) -> Option<Vec<f64>> {
+        if scaling.len() != self.m_orig {
+            return None;
+        }
+        Some(self.row_map.iter().map(|&orig| scaling[orig]).collect())
+    }
+
+    pub(crate) fn expand_x(&self, x_reduced: &[f64]) -> Vec<f64> {
+        let mut x_full = self.fixed_values.clone();
+        for (reduced, &orig) in self.var_map.iter().enumerate() {
+            x_full[orig] = x_reduced[reduced];
+        }
+        x_full
+    }
+
+    pub(crate) fn unmap_solution(
+        &self,
+        inner: &dyn NlpProblem,
+        reduced: &SolveResult,
+    ) -> SolveResult {
+        self.unmap_solution_with_options(inner, reduced, None)
+    }
+
+    pub(crate) fn unmap_solution_with_options(
+        &self,
+        inner: &dyn NlpProblem,
+        reduced: &SolveResult,
+        options: Option<&SolverOptions>,
+    ) -> SolveResult {
+        let x_full = self.expand_x(&reduced.x);
+
+        let mut constraint_multipliers = vec![0.0; self.m_orig];
+        for (reduced_idx, &orig_idx) in self.row_map.iter().enumerate() {
+            if reduced_idx < reduced.constraint_multipliers.len() {
+                constraint_multipliers[orig_idx] = reduced.constraint_multipliers[reduced_idx];
+            }
+        }
+
+        let mut bound_multipliers_lower = vec![0.0; self.n_orig];
+        let mut bound_multipliers_upper = vec![0.0; self.n_orig];
+        for (reduced_idx, &orig_idx) in self.var_map.iter().enumerate() {
+            if reduced_idx < reduced.bound_multipliers_lower.len() {
+                bound_multipliers_lower[orig_idx] = reduced.bound_multipliers_lower[reduced_idx];
+            }
+            if reduced_idx < reduced.bound_multipliers_upper.len() {
+                bound_multipliers_upper[orig_idx] = reduced.bound_multipliers_upper[reduced_idx];
+            }
+        }
+
+        if self.multiplier_recovery == RemovedMultiplierRecovery::AuxiliaryStationarity {
+            if let Err(reason) = self.reconstruct_removed_constraint_multipliers(
+                inner,
+                &x_full,
+                &mut constraint_multipliers,
+                &bound_multipliers_lower,
+                &bound_multipliers_upper,
+            ) {
+                if let Some(options) = options {
+                    if options.print_level >= 5 {
+                        rip_log!(
+                            "ripopt: Auxiliary multiplier reconstruction skipped: {}",
+                            reason
+                        );
+                    }
+                }
+            }
+        }
+
+        let mut objective = reduced.objective;
+        let _ = inner.objective(&x_full, true, &mut objective);
+
+        let mut constraint_values = vec![0.0; self.m_orig];
+        if self.m_orig > 0 {
+            let _ = inner.constraints(&x_full, true, &mut constraint_values);
+        }
+
+        SolveResult {
+            x: x_full,
+            objective,
+            constraint_multipliers,
+            bound_multipliers_lower,
+            bound_multipliers_upper,
+            constraint_values,
+            status: reduced.status,
+            iterations: reduced.iterations,
+            diagnostics: reduced.diagnostics.clone(),
+        }
+    }
+
+    fn reconstruct_removed_constraint_multipliers(
+        &self,
+        inner: &dyn NlpProblem,
+        x_full: &[f64],
+        constraint_multipliers: &mut [f64],
+        bound_multipliers_lower: &[f64],
+        bound_multipliers_upper: &[f64],
+    ) -> Result<(), &'static str> {
+        let removed_rows = self.removed_rows();
+        let removed_vars = self.removed_vars();
+        if removed_rows.is_empty() && removed_vars.is_empty() {
+            return Ok(());
+        }
+        if removed_rows.len() != removed_vars.len() {
+            return Err("removed auxiliary row/variable counts are not square");
+        }
+        if removed_rows.is_empty() {
+            return Ok(());
+        }
+        if self.removed_vars_have_bound_ambiguity(inner, &removed_vars, x_full) {
+            return Err("removed auxiliary variable is active at a finite bound");
+        }
+
+        let mut grad = vec![0.0; self.n_orig];
+        if !inner.gradient(x_full, true, &mut grad) {
+            return Err("full gradient evaluation failed");
+        }
+
+        let (jac_rows, jac_cols) = inner.jacobian_structure();
+        if jac_rows.len() != jac_cols.len() {
+            return Err("Jacobian structure has mismatched row/column lengths");
+        }
+        let mut jac_vals = vec![0.0; jac_rows.len()];
+        if !inner.jacobian_values(x_full, true, &mut jac_vals) {
+            return Err("full Jacobian evaluation failed");
+        }
+
+        let row_pos = index_positions(self.m_orig, &removed_rows);
+        let var_pos = index_positions(self.n_orig, &removed_vars);
+        let dim = removed_rows.len();
+        let mut system = vec![0.0; dim * dim];
+        let mut rhs: Vec<f64> = removed_vars
+            .iter()
+            .map(|&var| -(grad[var] - bound_multipliers_lower[var] + bound_multipliers_upper[var]))
+            .collect();
+
+        for (idx, (&row, &col)) in jac_rows.iter().zip(jac_cols.iter()).enumerate() {
+            if row >= self.m_orig || col >= self.n_orig {
+                continue;
+            }
+            let val = jac_vals[idx];
+            if !val.is_finite() {
+                return Err("Jacobian contains a non-finite value");
+            }
+            let Some(var_local) = var_pos[col] else {
+                continue;
+            };
+            if let Some(row_local) = row_pos[row] {
+                system[var_local * dim + row_local] += val;
+            } else {
+                rhs[var_local] -= val * constraint_multipliers[row];
+            }
+        }
+
+        let lambda = solve_dense_square_system(system, rhs, dim)?;
+        for (local, &row) in removed_rows.iter().enumerate() {
+            constraint_multipliers[row] = lambda[local];
+        }
+        Ok(())
+    }
+
+    fn removed_vars_have_bound_ambiguity(
+        &self,
+        inner: &dyn NlpProblem,
+        removed_vars: &[usize],
+        x_full: &[f64],
+    ) -> bool {
+        let mut x_l = vec![0.0; self.n_orig];
+        let mut x_u = vec![0.0; self.n_orig];
+        inner.bounds(&mut x_l, &mut x_u);
+        removed_vars.iter().any(|&var| {
+            let x = x_full[var];
+            let scale_l = x.abs().max(x_l[var].abs()).max(1.0);
+            let scale_u = x.abs().max(x_u[var].abs()).max(1.0);
+            (x_l[var].is_finite() && x <= x_l[var] + 1e-8 * scale_l)
+                || (x_u[var].is_finite() && x >= x_u[var] - 1e-8 * scale_u)
+        })
+    }
+}
+
+pub(crate) struct ReductionStack<'a> {
+    layers: Vec<ReductionLayer<'a>>,
+}
+
+struct ReductionLayer<'a> {
+    frame: &'a ReductionFrame,
+    inner: &'a dyn NlpProblem,
+}
+
+impl<'a> ReductionStack<'a> {
+    pub(crate) fn new() -> Self {
+        Self { layers: Vec::new() }
+    }
+
+    pub(crate) fn push(mut self, frame: &'a ReductionFrame, inner: &'a dyn NlpProblem) -> Self {
+        self.layers.push(ReductionLayer { frame, inner });
+        self
+    }
+
+    pub(crate) fn unmap_solution_with_options(
+        &self,
+        reduced: &SolveResult,
+        options: Option<&SolverOptions>,
+    ) -> SolveResult {
+        let mut current = reduced.clone();
+        for layer in &self.layers {
+            current = layer
+                .frame
+                .unmap_solution_with_options(layer.inner, &current, options);
+        }
+        current
+    }
+}
+
+fn removed_indices(total: usize, kept: &[usize]) -> Vec<usize> {
+    let mut is_kept = vec![false; total];
+    for &idx in kept {
+        if idx < total {
+            is_kept[idx] = true;
+        }
+    }
+    (0..total).filter(|&idx| !is_kept[idx]).collect()
+}
+
+fn index_positions(total: usize, indices: &[usize]) -> Vec<Option<usize>> {
+    let mut positions = vec![None; total];
+    for (pos, &idx) in indices.iter().enumerate() {
+        if idx < total {
+            positions[idx] = Some(pos);
+        }
+    }
+    positions
+}
+
+pub(crate) fn solve_dense_square_system(
+    mut matrix: Vec<f64>,
+    mut rhs: Vec<f64>,
+    dim: usize,
+) -> Result<Vec<f64>, &'static str> {
+    if dim == 0 {
+        return Ok(Vec::new());
+    }
+    if matrix.len() != dim * dim || rhs.len() != dim {
+        return Err("dense system dimensions are inconsistent");
+    }
+    if matrix.iter().any(|value| !value.is_finite()) {
+        return Err("dense system matrix contains a non-finite value");
+    }
+    if rhs.iter().any(|value| !value.is_finite()) {
+        return Err("dense system RHS contains a non-finite value");
+    }
+
+    let matrix_norm = matrix
+        .iter()
+        .fold(0.0_f64, |acc, &value| acc.max(value.abs()));
+    if matrix_norm == 0.0 {
+        return Err("dense system matrix is zero");
+    }
+
+    let original_matrix = matrix.clone();
+    let original_rhs = rhs.clone();
+    let pivot_tol = (dim as f64) * matrix_norm * 1e-10;
+
+    for col in 0..dim {
+        let pivot_row = (col..dim)
+            .max_by(|&a, &b| {
+                matrix[a * dim + col]
+                    .abs()
+                    .partial_cmp(&matrix[b * dim + col].abs())
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .ok_or("dense system has no pivot row")?;
+        let pivot_abs = matrix[pivot_row * dim + col].abs();
+        if pivot_abs <= pivot_tol {
+            return Err("dense system is singular or ill-conditioned");
+        }
+        if pivot_row != col {
+            for j in col..dim {
+                matrix.swap(col * dim + j, pivot_row * dim + j);
+            }
+            rhs.swap(col, pivot_row);
+        }
+
+        let pivot = matrix[col * dim + col];
+        for row in (col + 1)..dim {
+            let factor = matrix[row * dim + col] / pivot;
+            matrix[row * dim + col] = 0.0;
+            for j in (col + 1)..dim {
+                matrix[row * dim + j] -= factor * matrix[col * dim + j];
+            }
+            rhs[row] -= factor * rhs[col];
+        }
+    }
+
+    let mut solution = vec![0.0; dim];
+    for i in (0..dim).rev() {
+        let mut sum = rhs[i];
+        for j in (i + 1)..dim {
+            sum -= matrix[i * dim + j] * solution[j];
+        }
+        let pivot = matrix[i * dim + i];
+        if pivot.abs() <= pivot_tol {
+            return Err("dense system is singular or ill-conditioned");
+        }
+        solution[i] = sum / pivot;
+    }
+    if solution.iter().any(|value| !value.is_finite()) {
+        return Err("dense system solution is non-finite");
+    }
+
+    let residual = dense_residual_inf(&original_matrix, &solution, &original_rhs, dim);
+    let rhs_norm = original_rhs
+        .iter()
+        .fold(0.0_f64, |acc, &value| acc.max(value.abs()));
+    if residual > 1e-8 * rhs_norm.max(1.0) {
+        return Err("dense system residual is too large");
+    }
+
+    Ok(solution)
+}
+
+fn dense_residual_inf(matrix: &[f64], x: &[f64], rhs: &[f64], dim: usize) -> f64 {
+    let mut residual: f64 = 0.0;
+    for row in 0..dim {
+        let mut ax = 0.0;
+        for col in 0..dim {
+            ax += matrix[row * dim + col] * x[col];
+        }
+        residual = residual.max((ax - rhs[row]).abs());
+    }
+    residual
+}


### PR DESCRIPTION
## Summary
- Added a crate-private `ReductionFrame`/`ReductionStack` for preprocessing solution transfer, including primal expansion, row and multiplier expansion, fixed removed-variable values, removed-row tracking, and auxiliary multiplier reconstruction.
- Refactored standard preprocessing and auxiliary reductions to use the shared frame logic while keeping public Rust, C, Python, and AMPL option surfaces unchanged.
- Added a composition test for auxiliary reduction followed by standard preprocessing that verifies primal variables, constraint values, constraint multipliers, and bound multipliers.

## Tests run
- `cargo test reduction_stack_composes_auxiliary_then_standard_unmapping` - passed.
- `cargo test auxiliary_preprocessing::tests::` - passed: 67 tests.
- `cargo test ipm_preprocessing_integration` - passed.
- `cargo test auxiliary_postsolve_recovers_equality_variable_after_reduced_solve` - passed.
- `cargo test` - passed, including doctests; repository-configured ignored tests remained ignored.
- `cargo nextest run` - passed: 379 tests run, 379 passed, 25 skipped.
- `cargo test --doc` - passed: 1 doctest.
- `make test-c` - passed: release build plus C API examples.
- `git diff --cached --check` - passed.

## Notes
- No separate documented lint, type-check, or formatting command was found in README, Makefile, Cargo metadata, or CI beyond the Rust test/build commands above.
- Ignored large-scale/benchmark tests were not run locally.

Closes #27
