### PR TITLE
Profile preprocessing overhead diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,7 @@ Key options (all have Ipopt-matching defaults):
 - `constraint_values` -- constraint values g(x*)
 - `status` -- one of: `Optimal`, `Infeasible`, `LocalInfeasibility`, `MaxIterations`, `NumericalError`, `Unbounded`, `RestorationFailed`, `InternalError`
 - `iterations` -- number of IPM iterations
+- `diagnostics` -- `SolverDiagnostics`, including residuals, timing/evaluation counters, fallback information, and nested `diagnostics.preprocessing` phase data. The same diagnostics object is included in CLI JSON reports.
 
 ## C API
 

--- a/docs/diagnostics-guide.md
+++ b/docs/diagnostics-guide.md
@@ -4,7 +4,10 @@
 
 `SolverDiagnostics` captures structured data about solver behavior during a
 solve. It is available both programmatically via `result.diagnostics` and as a
-stderr summary block (printed when `print_level >= 5`).
+stderr summary block (printed when `print_level >= 5`). JSON reports written
+with `ripopt problem.nl -o report.json` include the full diagnostics object,
+including preprocessing diagnostics that are not expanded in the compact stderr
+summary.
 
 The diagnostic block looks like:
 
@@ -42,6 +45,53 @@ soc_corrections: 0
 | `final_compl` | Complementarity error at termination |
 | `wall_time_secs` | Total wall-clock time |
 | `fallback_used` | Which fallback succeeded, if any (`lbfgs_hessian`, `augmented_lagrangian`, `sqp`, `slack`) |
+| `preprocessing` | Nested diagnostics for auxiliary presolve, auxiliary postsolve, and standard preprocessing |
+
+## Preprocessing diagnostics
+
+`diagnostics.preprocessing` is useful when `enable_preprocessing` changes
+iteration counts but not wall time. It is split into:
+
+| Object | Purpose |
+|---|---|
+| `preprocessing.presolve` | Auxiliary equality-block reduction before the main solve |
+| `preprocessing.postsolve` | Auxiliary reduction followed by recovery of eliminated variables |
+| `preprocessing.standard` | Fixed-variable and redundant-constraint preprocessing |
+
+For `preprocessing.presolve` and `preprocessing.postsolve`, the most useful
+fields are:
+
+| Field | Meaning |
+|---|---|
+| `attempted`, `solved`, `failed` | Whether the phase ran, solved through preprocessing, or rejected/fell back |
+| `total_time_secs` | Total wall-clock time spent in the phase |
+| `candidate_detection_time_secs` | Candidate search time, including incidence, filtering, and structural analysis |
+| `incidence_time_secs` | Time spent constructing equality-incidence data |
+| `structural_analysis_time_secs` | Time spent on components, matching, Dulmage-Mendelsohn, and block-triangular analysis |
+| `candidate_filter_time_secs` | Time spent excluding objective- or inequality-coupled variables |
+| `auxiliary_solve_time_secs` | Presolve time spent solving accepted auxiliary blocks |
+| `recovery_solve_time_secs` | Postsolve time spent recovering eliminated variables |
+| `reduction_build_time_secs` | Time spent constructing the auxiliary-reduced problem |
+| `nested_preprocessing_time_secs` | Time spent applying standard preprocessing to the reduced problem |
+| `reduced_solve_time_secs` | Time spent solving the reduced problem |
+| `unmap_time_secs` | Time spent mapping the reduced solution back to the original variables and constraints |
+| `full_space_validation_time_secs` | Time spent recomputing objective, constraints, and residuals on the original problem |
+| `equality_rows`, `incident_variables`, `connected_components` | Equality-incidence structure size |
+| `candidates`, `btd_blocks`, `accepted_block_sizes` | Accepted auxiliary candidate and block structure |
+| `rejected_blocks`, `rejection_counts` | Rejection totals grouped by reason |
+| `auxiliary_blocks_solved`, `auxiliary_iterations`, `auxiliary_*_evals` | Internal auxiliary solve work |
+| `original_*`, `reduced_*`, `removed_*`, `nested_*` | Original, reduced, removed, and nested preprocessing dimensions |
+
+For `preprocessing.standard`, use `attempted`, `did_reduce`,
+`total_time_secs`, `construction_time_secs`, `reduced_solve_time_secs`,
+`unmap_time_secs`, `fixed_variables`, `redundant_constraints`, and the
+original/reduced dimensions.
+
+When preprocessing is slower than the no-preprocessing solve, compare
+`wall_time_secs` with the phase totals. High `candidate_detection_time_secs`
+points to structural overhead; high `auxiliary_solve_time_secs` or
+`recovery_solve_time_secs` points to internal block solves; high
+`reduced_solve_time_secs` means the reduced NLP itself still dominates.
 
 ## Reading the diagnostics
 

--- a/docs/src/diagnostics.md
+++ b/docs/src/diagnostics.md
@@ -1,6 +1,9 @@
 # Diagnostics
 
-`SolverDiagnostics` captures structured data about solver behavior. It is available at `result.diagnostics` and printed to stderr when `print_level >= 5`.
+`SolverDiagnostics` captures structured data about solver behavior. It is
+available at `result.diagnostics`; the compact summary below is printed to
+stderr when `print_level >= 5`. Structured JSON reports include the full
+diagnostics object, including preprocessing details.
 
 ## Diagnostic block format
 
@@ -40,6 +43,50 @@ soc_corrections: 0
 | `watchdog_activations` | Watchdog triggered by consecutive short steps |
 | `soc_corrections` | Second-order corrections accepted |
 | `fallback_used` | Which fallback succeeded, if any (`lbfgs_hessian`, `augmented_lagrangian`, `sqp`, `slack`) |
+| `preprocessing` | Nested diagnostics for auxiliary presolve, auxiliary postsolve, and standard preprocessing |
+
+## Preprocessing Diagnostics
+
+`diagnostics.preprocessing` is always present in `SolveResult` and in CLI JSON
+reports written with `ripopt problem.nl -o report.json`. It has three nested
+objects:
+
+| Object | Meaning |
+|---|---|
+| `preprocessing.presolve` | Auxiliary equality-block reduction attempted before the main solve |
+| `preprocessing.postsolve` | Auxiliary equality-block reduction followed by recovery after a reduced solve |
+| `preprocessing.standard` | Fixed-variable and redundant-constraint preprocessing |
+
+The auxiliary objects, `presolve` and `postsolve`, report both timing and
+structural data:
+
+| Field | Meaning |
+|---|---|
+| `attempted`, `solved`, `failed` | Whether the phase ran, solved the problem, or rejected/fell back |
+| `total_time_secs` | Total wall-clock time spent in that preprocessing phase |
+| `candidate_detection_time_secs` | End-to-end candidate search time |
+| `incidence_time_secs` | Time spent building equality incidence data |
+| `structural_analysis_time_secs` | Time spent on components, matching, Dulmage-Mendelsohn, and block-triangular analysis |
+| `candidate_filter_time_secs` | Time spent rejecting objective- or inequality-coupled variables |
+| `auxiliary_solve_time_secs` | Presolve time spent solving accepted auxiliary blocks |
+| `recovery_solve_time_secs` | Postsolve time spent recovering eliminated variables |
+| `reduction_build_time_secs` | Time spent wrapping the reduced problem |
+| `nested_preprocessing_time_secs` | Time spent running standard preprocessing on the auxiliary-reduced problem |
+| `reduced_solve_time_secs` | Time spent solving the reduced problem |
+| `unmap_time_secs` | Time spent mapping reduced solutions back to the original space |
+| `full_space_validation_time_secs` | Time spent recomputing objective, constraints, and residuals on the original problem |
+| `equality_rows`, `incident_variables`, `connected_components` | Size of the equality-incidence structure examined |
+| `candidates`, `btd_blocks`, `accepted_block_sizes` | Accepted auxiliary candidate and block structure |
+| `rejected_blocks`, `rejection_counts` | Rejection totals grouped by reason |
+| `auxiliary_blocks_solved`, `auxiliary_iterations`, `auxiliary_*_evals` | Work performed by internal auxiliary solves |
+| `original_*`, `reduced_*`, `removed_*`, `nested_*` | Original, reduced, removed, and nested standard-preprocessing dimensions |
+
+The standard object reports `attempted`, `did_reduce`, `total_time_secs`,
+`construction_time_secs`, `reduced_solve_time_secs`, `unmap_time_secs`,
+original/reduced dimensions, `fixed_variables`, and `redundant_constraints`.
+Use these fields to separate "preprocessing found no useful structure" from
+"preprocessing reduced the model but the overhead exceeded the iteration
+savings."
 
 ## Interpreting the diagnostics
 

--- a/src/auxiliary_preprocessing.rs
+++ b/src/auxiliary_preprocessing.rs
@@ -56,6 +56,13 @@ pub(crate) struct AuxiliarySolveOutcome {
     pub(crate) x: Vec<f64>,
     pub(crate) blocks_solved: usize,
     pub(crate) max_residual: f64,
+    pub(crate) total_iterations: usize,
+    pub(crate) total_wall_time_secs: f64,
+    pub(crate) total_obj_evals: usize,
+    pub(crate) total_grad_evals: usize,
+    pub(crate) total_constr_evals: usize,
+    pub(crate) total_jac_evals: usize,
+    pub(crate) total_hess_evals: usize,
 }
 
 #[allow(dead_code)]
@@ -117,7 +124,7 @@ pub(crate) enum AuxiliaryRejectionReason {
 }
 
 impl AuxiliaryRejectionReason {
-    fn label(&self) -> &'static str {
+    pub(crate) fn label(&self) -> &'static str {
         match self {
             Self::EmptyComponent => "empty component",
             Self::NonSquareComponent { .. } => "non-square component",
@@ -149,7 +156,7 @@ pub(crate) struct AuxiliaryRejection {
 }
 
 #[allow(dead_code)]
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub(crate) struct AuxiliaryCandidateDiagnostics {
     pub(crate) equality_rows: usize,
     pub(crate) incident_variables: usize,
@@ -164,6 +171,9 @@ pub(crate) struct AuxiliaryCandidateDiagnostics {
     pub(crate) objective_and_inequality_coupled_candidates: usize,
     pub(crate) accepted_blocks: Vec<EqualityBlock>,
     pub(crate) rejections: Vec<AuxiliaryRejection>,
+    pub(crate) incidence_time_secs: f64,
+    pub(crate) structural_analysis_time_secs: f64,
+    pub(crate) candidate_filter_time_secs: f64,
 }
 
 impl AuxiliaryCandidateDiagnostics {
@@ -1017,6 +1027,13 @@ pub(crate) fn solve_auxiliary_blocks_from(
 ) -> Result<AuxiliarySolveOutcome, AuxiliarySolveError> {
     let mut blocks_solved = 0;
     let mut max_residual: f64 = 0.0;
+    let mut total_iterations = 0;
+    let mut total_wall_time_secs = 0.0;
+    let mut total_obj_evals = 0;
+    let mut total_grad_evals = 0;
+    let mut total_constr_evals = 0;
+    let mut total_jac_evals = 0;
+    let mut total_hess_evals = 0;
 
     for candidate in candidates {
         for block in &candidate.blocks {
@@ -1044,6 +1061,13 @@ pub(crate) fn solve_auxiliary_blocks_from(
             }
             blocks_solved += 1;
             max_residual = max_residual.max(residual);
+            total_iterations += result.iterations;
+            total_wall_time_secs += result.diagnostics.wall_time_secs;
+            total_obj_evals += result.diagnostics.n_obj_evals;
+            total_grad_evals += result.diagnostics.n_grad_evals;
+            total_constr_evals += result.diagnostics.n_constr_evals;
+            total_jac_evals += result.diagnostics.n_jac_evals;
+            total_hess_evals += result.diagnostics.n_hess_evals;
         }
     }
 
@@ -1051,6 +1075,13 @@ pub(crate) fn solve_auxiliary_blocks_from(
         x: x_full.to_vec(),
         blocks_solved,
         max_residual,
+        total_iterations,
+        total_wall_time_secs,
+        total_obj_evals,
+        total_grad_evals,
+        total_constr_evals,
+        total_jac_evals,
+        total_hess_evals,
     })
 }
 
@@ -1224,12 +1255,15 @@ pub(crate) fn find_presolve_candidates_with_diagnostics(
     problem: &dyn NlpProblem,
     tol: f64,
 ) -> (Vec<PresolveCandidate>, AuxiliaryCandidateDiagnostics) {
+    let incidence_start = Instant::now();
     let incidence = EqualityIncidence::from_problem(problem, tol);
     let mut diagnostics = AuxiliaryCandidateDiagnostics::from_incidence(&incidence);
+    diagnostics.incidence_time_secs = incidence_start.elapsed().as_secs_f64();
     if incidence.row_global.is_empty() {
         return (Vec::new(), diagnostics);
     }
 
+    let structural_start = Instant::now();
     let selected_rows: Vec<_> = (0..incidence.row_adj_vars.len()).collect();
     let selected_vars: Vec<_> = incidence
         .var_adj_rows
@@ -1237,9 +1271,14 @@ pub(crate) fn find_presolve_candidates_with_diagnostics(
         .enumerate()
         .filter_map(|(var, rows)| (!rows.is_empty()).then_some(var))
         .collect();
+    diagnostics.structural_analysis_time_secs += structural_start.elapsed().as_secs_f64();
+
+    let filter_start = Instant::now();
     let objective_independent = objective_independent_variables(problem, tol);
     let inequality_coupled = variables_in_inequality_rows(problem, tol);
+    diagnostics.candidate_filter_time_secs += filter_start.elapsed().as_secs_f64();
 
+    let structural_start = Instant::now();
     let components = incidence
         .connected_components(&selected_rows, &selected_vars)
         .into_iter()
@@ -1280,6 +1319,7 @@ pub(crate) fn find_presolve_candidates_with_diagnostics(
             }
         }
     }
+    diagnostics.structural_analysis_time_secs += structural_start.elapsed().as_secs_f64();
     (candidates, diagnostics)
 }
 
@@ -1296,14 +1336,20 @@ pub(crate) fn find_postsolve_candidates_with_diagnostics(
     problem: &dyn NlpProblem,
     tol: f64,
 ) -> (Vec<PresolveCandidate>, AuxiliaryCandidateDiagnostics) {
+    let incidence_start = Instant::now();
     let incidence = EqualityIncidence::from_problem(problem, tol);
     let mut diagnostics = AuxiliaryCandidateDiagnostics::from_incidence(&incidence);
+    diagnostics.incidence_time_secs = incidence_start.elapsed().as_secs_f64();
     if incidence.row_global.is_empty() {
         return (Vec::new(), diagnostics);
     }
 
+    let filter_start = Instant::now();
     let objective_independent = objective_independent_variables(problem, tol);
     let inequality_coupled = variables_in_inequality_rows(problem, tol);
+    diagnostics.candidate_filter_time_secs += filter_start.elapsed().as_secs_f64();
+
+    let structural_start = Instant::now();
     let selected_vars: Vec<_> = incidence
         .var_adj_rows
         .iter()
@@ -1316,6 +1362,7 @@ pub(crate) fn find_postsolve_candidates_with_diagnostics(
         })
         .collect();
     if selected_vars.is_empty() {
+        diagnostics.structural_analysis_time_secs += structural_start.elapsed().as_secs_f64();
         return (Vec::new(), diagnostics);
     }
 
@@ -1349,6 +1396,7 @@ pub(crate) fn find_postsolve_candidates_with_diagnostics(
             candidates.push(candidate);
         }
     }
+    diagnostics.structural_analysis_time_secs += structural_start.elapsed().as_secs_f64();
     (candidates, diagnostics)
 }
 

--- a/src/ipm.rs
+++ b/src/ipm.rs
@@ -1,4 +1,5 @@
 use std::cell::RefCell;
+use std::collections::BTreeMap;
 use std::time::{Duration, Instant};
 
 use crate::convergence::{self, ConvergenceInfo, ConvergenceStatus};
@@ -82,7 +83,10 @@ use crate::options::SolverOptions;
 use crate::problem::NlpProblem;
 use crate::trace;
 use crate::restoration_nlp::RestorationNlp;
-use crate::result::{SolveResult, SolverDiagnostics, SolveStatus};
+use crate::result::{
+    AuxiliaryPreprocessingDiagnostics, PreprocessingDiagnostics, PreprocessingRejectionCount,
+    SolveResult, SolverDiagnostics, SolveStatus, StandardPreprocessingDiagnostics,
+};
 use crate::warmstart::WarmStartInitializer;
 use crate::logging::rip_log;
 
@@ -2237,6 +2241,67 @@ enum AuxiliaryPreprocessAttempt {
     Failed,
 }
 
+fn copy_auxiliary_candidate_diagnostics(
+    target: &mut AuxiliaryPreprocessingDiagnostics,
+    candidate_count: usize,
+    diagnostics: &crate::auxiliary_preprocessing::AuxiliaryCandidateDiagnostics,
+) {
+    target.equality_rows = diagnostics.equality_rows;
+    target.incident_variables = diagnostics.incident_variables;
+    target.connected_components = diagnostics.connected_components;
+    target.square_components = diagnostics.square_components;
+    target.closed_components = diagnostics.closed_components;
+    target.candidates = candidate_count;
+    target.pure_equality_candidates = diagnostics.pure_equality_candidates;
+    target.objective_coupled_candidates = diagnostics.objective_coupled_candidates;
+    target.inequality_coupled_candidates = diagnostics.inequality_coupled_candidates;
+    target.objective_and_inequality_coupled_candidates =
+        diagnostics.objective_and_inequality_coupled_candidates;
+    target.btd_blocks = diagnostics.btd_blocks;
+    target.rank_accepted_blocks = diagnostics.rank_accepted_blocks;
+    target.rejected_blocks = diagnostics.rejected_blocks();
+    target.accepted_block_sizes = diagnostics.accepted_block_sizes();
+    target.incidence_time_secs = diagnostics.incidence_time_secs;
+    target.structural_analysis_time_secs = diagnostics.structural_analysis_time_secs;
+    target.candidate_filter_time_secs = diagnostics.candidate_filter_time_secs;
+
+    let mut rejection_counts = BTreeMap::<String, usize>::new();
+    for rejection in &diagnostics.rejections {
+        *rejection_counts
+            .entry(rejection.reason.label().to_string())
+            .or_insert(0) += 1;
+    }
+    target.rejection_counts = rejection_counts
+        .into_iter()
+        .map(|(reason, count)| PreprocessingRejectionCount { reason, count })
+        .collect();
+}
+
+fn copy_auxiliary_solve_outcome(
+    target: &mut AuxiliaryPreprocessingDiagnostics,
+    outcome: &crate::auxiliary_preprocessing::AuxiliarySolveOutcome,
+) {
+    target.auxiliary_blocks_solved = outcome.blocks_solved;
+    target.auxiliary_max_residual = outcome.max_residual;
+    target.auxiliary_iterations = outcome.total_iterations;
+    target.auxiliary_wall_time_secs = outcome.total_wall_time_secs;
+    target.auxiliary_obj_evals = outcome.total_obj_evals;
+    target.auxiliary_grad_evals = outcome.total_grad_evals;
+    target.auxiliary_constr_evals = outcome.total_constr_evals;
+    target.auxiliary_jac_evals = outcome.total_jac_evals;
+    target.auxiliary_hess_evals = outcome.total_hess_evals;
+}
+
+fn finish_auxiliary_diagnostics(
+    target: &mut AuxiliaryPreprocessingDiagnostics,
+    candidate_count: usize,
+    diagnostics: &crate::auxiliary_preprocessing::AuxiliaryCandidateDiagnostics,
+    started: Instant,
+) {
+    copy_auxiliary_candidate_diagnostics(target, candidate_count, diagnostics);
+    target.total_time_secs += started.elapsed().as_secs_f64();
+}
+
 struct FullSpaceValidation {
     objective: f64,
     constraints: Vec<f64>,
@@ -2402,17 +2467,25 @@ fn try_auxiliary_preprocessed_solve<P: NlpProblem>(
     problem: &P,
     options: &SolverOptions,
     solve_start: Instant,
+    phase: &mut AuxiliaryPreprocessingDiagnostics,
 ) -> AuxiliaryPreprocessAttempt {
+    phase.attempted = true;
+    phase.original_variables = problem.num_variables();
+    phase.original_constraints = problem.num_constraints();
+    let phase_start = Instant::now();
     let problem_dyn = problem as &dyn NlpProblem;
+    let candidate_start = Instant::now();
     let (candidates, mut diagnostics) =
         crate::auxiliary_preprocessing::find_presolve_candidates_with_diagnostics(
             problem_dyn,
             options.auxiliary_tol,
         );
+    phase.candidate_detection_time_secs += candidate_start.elapsed().as_secs_f64();
     if candidates.is_empty() {
         if options.print_level >= 5 && diagnostics.equality_rows > 0 {
             diagnostics.log_verbose("Auxiliary preprocessing");
         }
+        finish_auxiliary_diagnostics(phase, candidates.len(), &diagnostics, phase_start);
         return AuxiliaryPreprocessAttempt::NoCandidates;
     }
 
@@ -2424,9 +2497,12 @@ fn try_auxiliary_preprocessed_solve<P: NlpProblem>(
         if options.print_level >= 5 {
             diagnostics.log_verbose("Auxiliary preprocessing");
         }
+        phase.failed = true;
+        finish_auxiliary_diagnostics(phase, candidates.len(), &diagnostics, phase_start);
         return AuxiliaryPreprocessAttempt::Failed;
     };
 
+    let auxiliary_solve_start = Instant::now();
     let outcome =
         match crate::auxiliary_preprocessing::solve_auxiliary_blocks(
             problem_dyn,
@@ -2444,6 +2520,9 @@ fn try_auxiliary_preprocessed_solve<P: NlpProblem>(
                 if options.print_level >= 5 {
                     diagnostics.log_verbose("Auxiliary preprocessing");
                 }
+                phase.auxiliary_solve_time_secs += auxiliary_solve_start.elapsed().as_secs_f64();
+                phase.failed = true;
+                finish_auxiliary_diagnostics(phase, candidates.len(), &diagnostics, phase_start);
                 return AuxiliaryPreprocessAttempt::Failed;
             }
             Err(err) => {
@@ -2452,9 +2531,14 @@ fn try_auxiliary_preprocessed_solve<P: NlpProblem>(
                     diagnostics.log_verbose("Auxiliary preprocessing");
                     rip_log!("ripopt: Auxiliary preprocessing skipped after failure: {:?}", err);
                 }
+                phase.auxiliary_solve_time_secs += auxiliary_solve_start.elapsed().as_secs_f64();
+                phase.failed = true;
+                finish_auxiliary_diagnostics(phase, candidates.len(), &diagnostics, phase_start);
                 return AuxiliaryPreprocessAttempt::Failed;
             }
         };
+    phase.auxiliary_solve_time_secs += auxiliary_solve_start.elapsed().as_secs_f64();
+    copy_auxiliary_solve_outcome(phase, &outcome);
     let blocks_solved = outcome.blocks_solved;
     let max_residual = outcome.max_residual;
 
@@ -2466,14 +2550,21 @@ fn try_auxiliary_preprocessed_solve<P: NlpProblem>(
         );
     }
 
+    let reduction_start = Instant::now();
     let reduced =
         match crate::auxiliary_preprocessing::AuxiliaryReducedProblem::new(problem_dyn, &candidates, outcome.x)
         {
             Ok(reduced) if reduced.did_reduce() => {
                 diagnostics.record_rank_accepted_candidates(&candidates);
+                phase.reduction_build_time_secs += reduction_start.elapsed().as_secs_f64();
+                phase.reduced_variables = reduced.num_variables();
+                phase.reduced_constraints = reduced.num_constraints();
+                phase.removed_variables = reduced.num_fixed();
+                phase.removed_constraints = reduced.num_removed_constraints();
                 reduced
             }
             Ok(_) => {
+                phase.reduction_build_time_secs += reduction_start.elapsed().as_secs_f64();
                 diagnostics.reject_global(
                     crate::auxiliary_preprocessing::AuxiliaryRejectionReason::ReductionDidNotRemoveAnything,
                     None,
@@ -2481,14 +2572,19 @@ fn try_auxiliary_preprocessed_solve<P: NlpProblem>(
                 if options.print_level >= 5 {
                     diagnostics.log_verbose("Auxiliary preprocessing");
                 }
+                phase.failed = true;
+                finish_auxiliary_diagnostics(phase, candidates.len(), &diagnostics, phase_start);
                 return AuxiliaryPreprocessAttempt::Failed;
             }
             Err(err) => {
+                phase.reduction_build_time_secs += reduction_start.elapsed().as_secs_f64();
                 diagnostics.record_auxiliary_error(&err, options.auxiliary_tol);
                 if options.print_level >= 5 {
                     diagnostics.log_verbose("Auxiliary preprocessing");
                     rip_log!("ripopt: Auxiliary preprocessing skipped after reduction failure: {:?}", err);
                 }
+                phase.failed = true;
+                finish_auxiliary_diagnostics(phase, candidates.len(), &diagnostics, phase_start);
                 return AuxiliaryPreprocessAttempt::Failed;
             }
         };
@@ -2506,7 +2602,13 @@ fn try_auxiliary_preprocessed_solve<P: NlpProblem>(
         );
     }
 
+    let nested_preprocessing_start = Instant::now();
     let prep = crate::preprocessing::PreprocessedProblem::new(&reduced as &dyn NlpProblem, options.bound_push);
+    phase.nested_preprocessing_time_secs += nested_preprocessing_start.elapsed().as_secs_f64();
+    phase.nested_reduced_variables = prep.num_variables();
+    phase.nested_reduced_constraints = prep.num_constraints();
+    phase.nested_fixed_variables = prep.num_fixed();
+    phase.nested_redundant_constraints = prep.num_redundant();
     if options.print_level >= 5 && prep.did_reduce() {
         rip_log!(
             "ripopt: Auxiliary nested preprocessing reduced problem: {} fixed vars, {} redundant constraints ({}x{} -> {}x{})",
@@ -2526,20 +2628,31 @@ fn try_auxiliary_preprocessed_solve<P: NlpProblem>(
         if options.print_level >= 5 {
             diagnostics.log_verbose("Auxiliary preprocessing");
         }
+        phase.failed = true;
+        finish_auxiliary_diagnostics(phase, candidates.len(), &diagnostics, phase_start);
         return AuxiliaryPreprocessAttempt::Failed;
     };
 
+    let reduced_solve_start = Instant::now();
     let nested_result = solve(&prep, &reduced_opts);
+    phase.reduced_solve_time_secs += reduced_solve_start.elapsed().as_secs_f64();
+    let unmap_start = Instant::now();
     let stack = crate::reduction_frame::ReductionStack::new()
         .push(prep.reduction_frame(), &reduced as &dyn NlpProblem)
         .push(reduced.reduction_frame(), problem_dyn);
     let mut result = stack.unmap_solution_with_options(&nested_result, Some(options));
+    phase.unmap_time_secs += unmap_start.elapsed().as_secs_f64();
     if matches!(result.status, SolveStatus::Optimal) {
-        if let Some(validation) = validate_full_space_result(problem_dyn, &result, options) {
+        let validation_start = Instant::now();
+        let validation = validate_full_space_result(problem_dyn, &result, options);
+        phase.full_space_validation_time_secs += validation_start.elapsed().as_secs_f64();
+        if let Some(validation) = validation {
             result.objective = validation.objective;
             result.constraint_values = validation.constraints;
             result.diagnostics.final_primal_inf = validation.primal_inf;
             result.diagnostics.final_dual_inf = validation.dual_inf;
+            phase.solved = true;
+            finish_auxiliary_diagnostics(phase, candidates.len(), &diagnostics, phase_start);
             return AuxiliaryPreprocessAttempt::Solved(result);
         }
         diagnostics.reject_global(
@@ -2567,6 +2680,8 @@ fn try_auxiliary_preprocessed_solve<P: NlpProblem>(
             );
         }
     }
+    phase.failed = true;
+    finish_auxiliary_diagnostics(phase, candidates.len(), &diagnostics, phase_start);
     AuxiliaryPreprocessAttempt::Failed
 }
 
@@ -2578,17 +2693,25 @@ fn try_auxiliary_postsolve_solve<P: NlpProblem>(
     problem: &P,
     options: &SolverOptions,
     solve_start: Instant,
+    phase: &mut AuxiliaryPreprocessingDiagnostics,
 ) -> AuxiliaryPreprocessAttempt {
+    phase.attempted = true;
+    phase.original_variables = problem.num_variables();
+    phase.original_constraints = problem.num_constraints();
+    let phase_start = Instant::now();
     let problem_dyn = problem as &dyn NlpProblem;
+    let candidate_start = Instant::now();
     let (candidates, mut diagnostics) =
         crate::auxiliary_preprocessing::find_postsolve_candidates_with_diagnostics(
             problem_dyn,
             options.auxiliary_tol,
         );
+    phase.candidate_detection_time_secs += candidate_start.elapsed().as_secs_f64();
     if candidates.is_empty() {
         if options.print_level >= 5 && diagnostics.equality_rows > 0 {
             diagnostics.log_verbose("Auxiliary postsolve");
         }
+        finish_auxiliary_diagnostics(phase, candidates.len(), &diagnostics, phase_start);
         return AuxiliaryPreprocessAttempt::NoCandidates;
     }
 
@@ -2600,19 +2723,28 @@ fn try_auxiliary_postsolve_solve<P: NlpProblem>(
         if options.print_level >= 5 {
             diagnostics.log_verbose("Auxiliary postsolve");
         }
+        phase.failed = true;
+        finish_auxiliary_diagnostics(phase, candidates.len(), &diagnostics, phase_start);
         return AuxiliaryPreprocessAttempt::Failed;
     };
 
     let mut x_context = vec![0.0; problem.num_variables()];
     problem.initial_point(&mut x_context);
+    let reduction_start = Instant::now();
     let reduced =
         match crate::auxiliary_preprocessing::AuxiliaryReducedProblem::new(problem_dyn, &candidates, x_context.clone())
         {
             Ok(reduced) if reduced.did_reduce() => {
                 diagnostics.record_rank_accepted_candidates(&candidates);
+                phase.reduction_build_time_secs += reduction_start.elapsed().as_secs_f64();
+                phase.reduced_variables = reduced.num_variables();
+                phase.reduced_constraints = reduced.num_constraints();
+                phase.removed_variables = reduced.num_fixed();
+                phase.removed_constraints = reduced.num_removed_constraints();
                 reduced
             }
             Ok(_) => {
+                phase.reduction_build_time_secs += reduction_start.elapsed().as_secs_f64();
                 diagnostics.reject_global(
                     crate::auxiliary_preprocessing::AuxiliaryRejectionReason::ReductionDidNotRemoveAnything,
                     None,
@@ -2620,14 +2752,19 @@ fn try_auxiliary_postsolve_solve<P: NlpProblem>(
                 if options.print_level >= 5 {
                     diagnostics.log_verbose("Auxiliary postsolve");
                 }
+                phase.failed = true;
+                finish_auxiliary_diagnostics(phase, candidates.len(), &diagnostics, phase_start);
                 return AuxiliaryPreprocessAttempt::Failed;
             }
             Err(err) => {
+                phase.reduction_build_time_secs += reduction_start.elapsed().as_secs_f64();
                 diagnostics.record_auxiliary_error(&err, options.auxiliary_tol);
                 if options.print_level >= 5 {
                     diagnostics.log_verbose("Auxiliary postsolve");
                     rip_log!("ripopt: Auxiliary postsolve skipped after reduction failure: {:?}", err);
                 }
+                phase.failed = true;
+                finish_auxiliary_diagnostics(phase, candidates.len(), &diagnostics, phase_start);
                 return AuxiliaryPreprocessAttempt::Failed;
             }
         };
@@ -2645,7 +2782,13 @@ fn try_auxiliary_postsolve_solve<P: NlpProblem>(
         );
     }
 
+    let nested_preprocessing_start = Instant::now();
     let prep = crate::preprocessing::PreprocessedProblem::new(&reduced as &dyn NlpProblem, options.bound_push);
+    phase.nested_preprocessing_time_secs += nested_preprocessing_start.elapsed().as_secs_f64();
+    phase.nested_reduced_variables = prep.num_variables();
+    phase.nested_reduced_constraints = prep.num_constraints();
+    phase.nested_fixed_variables = prep.num_fixed();
+    phase.nested_redundant_constraints = prep.num_redundant();
     if options.print_level >= 5 && prep.did_reduce() {
         rip_log!(
             "ripopt: Auxiliary postsolve nested preprocessing reduced problem: {} fixed vars, {} redundant constraints ({}x{} -> {}x{})",
@@ -2665,13 +2808,19 @@ fn try_auxiliary_postsolve_solve<P: NlpProblem>(
         if options.print_level >= 5 {
             diagnostics.log_verbose("Auxiliary postsolve");
         }
+        phase.failed = true;
+        finish_auxiliary_diagnostics(phase, candidates.len(), &diagnostics, phase_start);
         return AuxiliaryPreprocessAttempt::Failed;
     };
 
+    let reduced_solve_start = Instant::now();
     let nested_result = solve(&prep, &reduced_opts);
+    phase.reduced_solve_time_secs += reduced_solve_start.elapsed().as_secs_f64();
+    let unmap_start = Instant::now();
     let standard_stack = crate::reduction_frame::ReductionStack::new()
         .push(prep.reduction_frame(), &reduced as &dyn NlpProblem);
     let auxiliary_result = standard_stack.unmap_solution_with_options(&nested_result, Some(options));
+    phase.unmap_time_secs += unmap_start.elapsed().as_secs_f64();
     if !matches!(auxiliary_result.status, SolveStatus::Optimal) {
         diagnostics.reject_global(
             crate::auxiliary_preprocessing::AuxiliaryRejectionReason::AuxiliarySolveFailure {
@@ -2686,14 +2835,19 @@ fn try_auxiliary_postsolve_solve<P: NlpProblem>(
                 auxiliary_result.status,
             );
         }
+        phase.failed = true;
+        finish_auxiliary_diagnostics(phase, candidates.len(), &diagnostics, phase_start);
         return AuxiliaryPreprocessAttempt::Failed;
     }
 
+    let unmap_start = Instant::now();
     let partial_stack = crate::reduction_frame::ReductionStack::new()
         .push(prep.reduction_frame(), &reduced as &dyn NlpProblem)
         .push(reduced.reduction_frame(), problem_dyn);
     let partial = partial_stack.unmap_solution_with_options(&nested_result, Some(options));
+    phase.unmap_time_secs += unmap_start.elapsed().as_secs_f64();
     x_context = partial.x;
+    let recovery_solve_start = Instant::now();
     let outcome = match crate::auxiliary_preprocessing::solve_auxiliary_blocks_from(
         problem_dyn,
         &candidates,
@@ -2710,6 +2864,9 @@ fn try_auxiliary_postsolve_solve<P: NlpProblem>(
             if options.print_level >= 5 {
                 diagnostics.log_verbose("Auxiliary postsolve");
             }
+            phase.recovery_solve_time_secs += recovery_solve_start.elapsed().as_secs_f64();
+            phase.failed = true;
+            finish_auxiliary_diagnostics(phase, candidates.len(), &diagnostics, phase_start);
             return AuxiliaryPreprocessAttempt::Failed;
         }
         Err(err) => {
@@ -2718,9 +2875,14 @@ fn try_auxiliary_postsolve_solve<P: NlpProblem>(
                 diagnostics.log_verbose("Auxiliary postsolve");
                 rip_log!("ripopt: Auxiliary postsolve recovery failed: {:?}", err);
             }
+            phase.recovery_solve_time_secs += recovery_solve_start.elapsed().as_secs_f64();
+            phase.failed = true;
+            finish_auxiliary_diagnostics(phase, candidates.len(), &diagnostics, phase_start);
             return AuxiliaryPreprocessAttempt::Failed;
         }
     };
+    phase.recovery_solve_time_secs += recovery_solve_start.elapsed().as_secs_f64();
+    copy_auxiliary_solve_outcome(phase, &outcome);
 
     if options.print_level >= 5 {
         rip_log!(
@@ -2730,28 +2892,42 @@ fn try_auxiliary_postsolve_solve<P: NlpProblem>(
         );
     }
 
+    let reduction_start = Instant::now();
     let recovered_reduced =
         match crate::auxiliary_preprocessing::AuxiliaryReducedProblem::new(problem_dyn, &candidates, outcome.x)
         {
-            Ok(reduced) => reduced,
+            Ok(reduced) => {
+                phase.reduction_build_time_secs += reduction_start.elapsed().as_secs_f64();
+                reduced
+            }
             Err(err) => {
+                phase.reduction_build_time_secs += reduction_start.elapsed().as_secs_f64();
                 diagnostics.record_auxiliary_error(&err, options.auxiliary_tol);
                 if options.print_level >= 5 {
                     diagnostics.log_verbose("Auxiliary postsolve");
                     rip_log!("ripopt: Auxiliary postsolve skipped after recovery validation failure: {:?}", err);
                 }
+                phase.failed = true;
+                finish_auxiliary_diagnostics(phase, candidates.len(), &diagnostics, phase_start);
                 return AuxiliaryPreprocessAttempt::Failed;
             }
         };
+    let unmap_start = Instant::now();
     let recovered_stack = crate::reduction_frame::ReductionStack::new()
         .push(prep.reduction_frame(), &reduced as &dyn NlpProblem)
         .push(recovered_reduced.reduction_frame(), problem_dyn);
     let mut result = recovered_stack.unmap_solution_with_options(&nested_result, Some(options));
-    if let Some(validation) = validate_full_space_result(problem_dyn, &result, options) {
+    phase.unmap_time_secs += unmap_start.elapsed().as_secs_f64();
+    let validation_start = Instant::now();
+    let validation = validate_full_space_result(problem_dyn, &result, options);
+    phase.full_space_validation_time_secs += validation_start.elapsed().as_secs_f64();
+    if let Some(validation) = validation {
         result.objective = validation.objective;
         result.constraint_values = validation.constraints;
         result.diagnostics.final_primal_inf = validation.primal_inf;
         result.diagnostics.final_dual_inf = validation.dual_inf;
+        phase.solved = true;
+        finish_auxiliary_diagnostics(phase, candidates.len(), &diagnostics, phase_start);
         return AuxiliaryPreprocessAttempt::Solved(result);
     }
     diagnostics.reject_global(
@@ -2764,6 +2940,8 @@ fn try_auxiliary_postsolve_solve<P: NlpProblem>(
             "ripopt: Auxiliary-postsolve result validation failed, retrying without auxiliary postsolve"
         );
     }
+    phase.failed = true;
+    finish_auxiliary_diagnostics(phase, candidates.len(), &diagnostics, phase_start);
     AuxiliaryPreprocessAttempt::Failed
 }
 
@@ -2780,11 +2958,20 @@ fn try_auxiliary_postsolve_solve<P: NlpProblem>(
 fn try_standard_preprocessed_solve<P: NlpProblem>(
     problem: &P,
     options: &SolverOptions,
+    diagnostics: &mut StandardPreprocessingDiagnostics,
 ) -> Option<SolveResult> {
     let make_parameter = matches!(
         options.fixed_variable_treatment,
         FixedVariableTreatment::MakeParameter
     );
+    if !options.enable_preprocessing && !make_parameter {
+        return None;
+    }
+    diagnostics.attempted = true;
+    diagnostics.original_variables = problem.num_variables();
+    diagnostics.original_constraints = problem.num_constraints();
+    let total_start = Instant::now();
+    let construction_start = Instant::now();
     let prep = if options.enable_preprocessing {
         crate::preprocessing::PreprocessedProblem::new(
             problem as &dyn NlpProblem,
@@ -2796,11 +2983,18 @@ fn try_standard_preprocessed_solve<P: NlpProblem>(
         // Ipopt 3.14's `TNLPAdapter` behavior.
         crate::preprocessing::PreprocessedProblem::new_fixed_only(problem as &dyn NlpProblem)
     } else {
-        return None;
+        unreachable!("standard preprocessing precondition checked above");
     };
+    diagnostics.construction_time_secs += construction_start.elapsed().as_secs_f64();
+    diagnostics.reduced_variables = prep.num_variables();
+    diagnostics.reduced_constraints = prep.num_constraints();
+    diagnostics.fixed_variables = prep.num_fixed();
+    diagnostics.redundant_constraints = prep.num_redundant();
     if !prep.did_reduce() {
+        diagnostics.total_time_secs += total_start.elapsed().as_secs_f64();
         return None;
     }
+    diagnostics.did_reduce = true;
     if options.print_level >= 5 {
         rip_log!(
             "ripopt: Preprocessing reduced problem: {} fixed vars, {} redundant constraints ({}x{} -> {}x{})",
@@ -2811,8 +3005,14 @@ fn try_standard_preprocessed_solve<P: NlpProblem>(
     }
     let mut prep_opts = options.clone();
     prep_opts.enable_preprocessing = false;
+    let reduced_solve_start = Instant::now();
     let reduced_result = solve(&prep, &prep_opts);
-    Some(prep.unmap_solution(&reduced_result))
+    diagnostics.reduced_solve_time_secs += reduced_solve_start.elapsed().as_secs_f64();
+    let unmap_start = Instant::now();
+    let result = prep.unmap_solution(&reduced_result);
+    diagnostics.unmap_time_secs += unmap_start.elapsed().as_secs_f64();
+    diagnostics.total_time_secs += total_start.elapsed().as_secs_f64();
+    Some(result)
 }
 
 /// Run preprocessing (presolve auxiliary equality-block reduction, postsolve
@@ -2826,22 +3026,33 @@ fn try_preprocessed_solve<P: NlpProblem>(
     problem: &P,
     options: &SolverOptions,
     solve_start: Instant,
+    diagnostics: &mut PreprocessingDiagnostics,
 ) -> Option<SolveResult> {
     if options.enable_preprocessing {
         if let AuxiliaryPreprocessAttempt::Solved(result) =
-            try_auxiliary_preprocessed_solve(problem, options, solve_start)
+            try_auxiliary_preprocessed_solve(
+                problem,
+                options,
+                solve_start,
+                &mut diagnostics.presolve,
+            )
         {
             return Some(result);
         }
 
         if let AuxiliaryPreprocessAttempt::Solved(result) =
-            try_auxiliary_postsolve_solve(problem, options, solve_start)
+            try_auxiliary_postsolve_solve(
+                problem,
+                options,
+                solve_start,
+                &mut diagnostics.postsolve,
+            )
         {
             return Some(result);
         }
     }
 
-    try_standard_preprocessed_solve(problem, options)
+    try_standard_preprocessed_solve(problem, options, &mut diagnostics.standard)
 }
 
 /// Compute the accepted step length and resulting θ for one Gauss–Newton
@@ -2913,10 +3124,19 @@ fn solve_inner<P: NlpProblem>(
     options: &SolverOptions,
     solve_start: Instant,
 ) -> SolveResult {
-    if let Some(result) = try_preprocessed_solve(problem, options, solve_start) {
+    let mut preprocessing_diagnostics = PreprocessingDiagnostics::default();
+    if let Some(mut result) =
+        try_preprocessed_solve(problem, options, solve_start, &mut preprocessing_diagnostics)
+    {
+        result.diagnostics.preprocessing = preprocessing_diagnostics;
+        result.diagnostics.wall_time_secs = solve_start.elapsed().as_secs_f64();
+        if options.print_level >= 4 {
+            print_final_summary(&result);
+        }
         return result;
     }
     let mut result = solve_ipm(problem, options);
+    result.diagnostics.preprocessing = preprocessing_diagnostics;
     result.diagnostics.wall_time_secs = solve_start.elapsed().as_secs_f64();
     if options.print_level >= 4 {
         print_final_summary(&result);
@@ -11861,7 +12081,8 @@ mod tests {
             capture_log,
             &mut logs as *mut Vec<String> as *mut c_void,
         )));
-        let _ = try_preprocessed_solve(&problem, &options, Instant::now());
+        let mut diagnostics = PreprocessingDiagnostics::default();
+        let _ = try_preprocessed_solve(&problem, &options, Instant::now(), &mut diagnostics);
         crate::logging::set_log_callback(None);
         logs
     }
@@ -11874,7 +12095,8 @@ mod tests {
             ..SolverOptions::default()
         };
 
-        let result = try_preprocessed_solve(&problem, &options, Instant::now());
+        let mut diagnostics = PreprocessingDiagnostics::default();
+        let result = try_preprocessed_solve(&problem, &options, Instant::now(), &mut diagnostics);
 
         assert!(result.is_none());
     }
@@ -11968,7 +12190,8 @@ mod tests {
             ..SolverOptions::default()
         };
 
-        let result = try_preprocessed_solve(&problem, &options, Instant::now())
+        let mut diagnostics = PreprocessingDiagnostics::default();
+        let result = try_preprocessed_solve(&problem, &options, Instant::now(), &mut diagnostics)
             .expect("auxiliary preprocessing should solve");
 
         assert_eq!(result.status, SolveStatus::Optimal);
@@ -11978,6 +12201,10 @@ mod tests {
         assert_eq!(result.constraint_values.len(), 1);
         assert!(result.constraint_values[0].abs() < 1e-8);
         assert!(result.diagnostics.final_primal_inf < 1e-8);
+        assert!(diagnostics.presolve.solved);
+        assert!(diagnostics.presolve.total_time_secs > 0.0);
+        assert_eq!(diagnostics.presolve.auxiliary_blocks_solved, 1);
+        assert_eq!(diagnostics.presolve.removed_variables, 1);
     }
 
     #[test]
@@ -12007,12 +12234,16 @@ mod tests {
             ..SolverOptions::default()
         };
 
-        let result = try_preprocessed_solve(&problem, &options, Instant::now())
+        let mut diagnostics = PreprocessingDiagnostics::default();
+        let result = try_preprocessed_solve(&problem, &options, Instant::now(), &mut diagnostics)
             .expect("auxiliary preprocessing should solve the reduced empty problem");
 
         assert_eq!(result.status, SolveStatus::Optimal);
         assert!((result.x[0] - 2.0).abs() < 1e-10);
         assert!(result.diagnostics.final_primal_inf < 1e-10);
+        assert!(diagnostics.presolve.solved);
+        assert_eq!(diagnostics.presolve.reduced_variables, 0);
+        assert_eq!(diagnostics.presolve.reduced_constraints, 0);
     }
 
     /// Phase 3f test helper: replace the constraint bounds on a

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,5 +1,93 @@
 use crate::logging::rip_log;
 
+/// Count of preprocessing rejections grouped by reason label.
+#[derive(Debug, Clone, Default, serde::Serialize)]
+pub struct PreprocessingRejectionCount {
+    pub reason: String,
+    pub count: usize,
+}
+
+/// Diagnostics for one auxiliary preprocessing attempt, either presolve or
+/// postsolve recovery.
+#[derive(Debug, Clone, Default, serde::Serialize)]
+pub struct AuxiliaryPreprocessingDiagnostics {
+    pub attempted: bool,
+    pub solved: bool,
+    pub failed: bool,
+    pub total_time_secs: f64,
+    pub candidate_detection_time_secs: f64,
+    pub incidence_time_secs: f64,
+    pub structural_analysis_time_secs: f64,
+    pub candidate_filter_time_secs: f64,
+    pub auxiliary_solve_time_secs: f64,
+    pub reduction_build_time_secs: f64,
+    pub nested_preprocessing_time_secs: f64,
+    pub reduced_solve_time_secs: f64,
+    pub recovery_solve_time_secs: f64,
+    pub unmap_time_secs: f64,
+    pub full_space_validation_time_secs: f64,
+    pub equality_rows: usize,
+    pub incident_variables: usize,
+    pub connected_components: usize,
+    pub square_components: usize,
+    pub closed_components: usize,
+    pub candidates: usize,
+    pub pure_equality_candidates: usize,
+    pub objective_coupled_candidates: usize,
+    pub inequality_coupled_candidates: usize,
+    pub objective_and_inequality_coupled_candidates: usize,
+    pub btd_blocks: usize,
+    pub rank_accepted_blocks: usize,
+    pub rejected_blocks: usize,
+    pub rejection_counts: Vec<PreprocessingRejectionCount>,
+    pub accepted_block_sizes: Vec<(usize, usize)>,
+    pub auxiliary_blocks_solved: usize,
+    pub auxiliary_max_residual: f64,
+    pub auxiliary_iterations: usize,
+    pub auxiliary_wall_time_secs: f64,
+    pub auxiliary_obj_evals: usize,
+    pub auxiliary_grad_evals: usize,
+    pub auxiliary_constr_evals: usize,
+    pub auxiliary_jac_evals: usize,
+    pub auxiliary_hess_evals: usize,
+    pub original_variables: usize,
+    pub original_constraints: usize,
+    pub reduced_variables: usize,
+    pub reduced_constraints: usize,
+    pub removed_variables: usize,
+    pub removed_constraints: usize,
+    pub nested_reduced_variables: usize,
+    pub nested_reduced_constraints: usize,
+    pub nested_fixed_variables: usize,
+    pub nested_redundant_constraints: usize,
+}
+
+/// Diagnostics for the standard fixed-variable / redundant-constraint
+/// preprocessing wrapper.
+#[derive(Debug, Clone, Default, serde::Serialize)]
+pub struct StandardPreprocessingDiagnostics {
+    pub attempted: bool,
+    pub did_reduce: bool,
+    pub total_time_secs: f64,
+    pub construction_time_secs: f64,
+    pub reduced_solve_time_secs: f64,
+    pub unmap_time_secs: f64,
+    pub original_variables: usize,
+    pub original_constraints: usize,
+    pub reduced_variables: usize,
+    pub reduced_constraints: usize,
+    pub fixed_variables: usize,
+    pub redundant_constraints: usize,
+}
+
+/// Preprocessing diagnostics grouped by preprocessing path.
+#[derive(Debug, Clone, Default, serde::Serialize)]
+pub struct PreprocessingDiagnostics {
+    pub presolve: AuxiliaryPreprocessingDiagnostics,
+    pub postsolve: AuxiliaryPreprocessingDiagnostics,
+    pub standard: StandardPreprocessingDiagnostics,
+}
+
 /// Status of the solve.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 pub enum SolveStatus {
@@ -104,6 +192,8 @@ pub struct SolverDiagnostics {
     pub n_constr_evals: usize,
     pub n_jac_evals: usize,
     pub n_hess_evals: usize,
+    /// Timing and structural diagnostics for preprocessing paths.
+    pub preprocessing: PreprocessingDiagnostics,
 }
 
 impl SolverDiagnostics {

--- a/src/solution_report.rs
+++ b/src/solution_report.rs
@@ -384,5 +384,6 @@ mod tests {
         assert!(json.contains("\"solver\""));
         assert!(json.contains("\"validation\""));
         assert!(json.contains("\"kkt_satisfied\""));
+        assert!(json.contains("\"preprocessing\""));
     }
 }

--- a/tests/nl_integration.rs
+++ b/tests/nl_integration.rs
@@ -523,6 +523,7 @@ fn nl_issue_23_executable_incidence_fixtures_compare_preprocessing() {
         let (fallback_problem, fallback_result) = solve_issue23_fixture(&fixture, false);
         let preprocessed = issue23_metrics(&pre_problem, &pre_result);
         let fallback = issue23_metrics(&fallback_problem, &fallback_result);
+        let presolve = &pre_result.diagnostics.preprocessing.presolve;
 
         eprintln!(
             "issue 23 {name}: preprocessing={preprocessed:?}, no_preprocessing={fallback:?}",
@@ -572,6 +573,35 @@ fn nl_issue_23_executable_incidence_fixtures_compare_preprocessing() {
             fixture.name,
             preprocessed.objective,
             fallback.objective
+        );
+        assert!(presolve.attempted, "{} should profile presolve", fixture.name);
+        assert!(presolve.solved, "{} should solve via presolve", fixture.name);
+        assert!(
+            presolve.candidates > 0,
+            "{} should report auxiliary candidates",
+            fixture.name
+        );
+        assert!(
+            presolve.auxiliary_blocks_solved > 0,
+            "{} should report auxiliary block solves",
+            fixture.name
+        );
+        assert_eq!(presolve.original_variables, pre_problem.num_variables());
+        assert_eq!(presolve.original_constraints, pre_problem.num_constraints());
+        assert!(
+            presolve.reduced_variables < presolve.original_variables,
+            "{} should report variable reduction",
+            fixture.name
+        );
+        assert!(
+            presolve.removed_constraints > 0,
+            "{} should report constraint reduction",
+            fixture.name
+        );
+        assert!(
+            !presolve.accepted_block_sizes.is_empty(),
+            "{} should report accepted block sizes",
+            fixture.name
         );
     }
 }
@@ -1054,6 +1084,22 @@ fn cli_writes_validated_json_report() {
 
     // Options are echoed back so the run can be reproduced.
     assert_eq!(v["options"]["print_level"], 0);
+    assert!(
+        v["diagnostics"]["preprocessing"].is_object(),
+        "JSON report should include preprocessing diagnostics"
+    );
+    assert_eq!(
+        v["diagnostics"]["preprocessing"]["presolve"]["attempted"],
+        true
+    );
+    assert_eq!(
+        v["diagnostics"]["preprocessing"]["standard"]["attempted"],
+        true
+    );
+    assert_eq!(
+        v["diagnostics"]["preprocessing"]["standard"]["did_reduce"],
+        false
+    );
 
     let _ = std::fs::remove_file(&tmp);
     let _ = std::fs::remove_file(&json_path);


### PR DESCRIPTION
## Summary

- Adds structured preprocessing diagnostics under `SolverDiagnostics`, grouped by auxiliary presolve, auxiliary postsolve, and standard preprocessing.
- Records phase timings for incidence construction, structural analysis, candidate filtering, auxiliary block solves, reduction wrapping, nested standard preprocessing, reduced solves, recovery, unmapping, and full-space validation.
- Records candidate counts, rejection reason counts, accepted block sizes, reduction dimensions, and auxiliary solve iteration/evaluation totals so benchmark JSON can explain preprocessing overhead.
- Extends JSON/report and NL integration tests to verify the new diagnostics are present for CLI reports and populated on the issue-23 auxiliary preprocessing fixtures.

## Tests run

- `cargo test report_serializes_to_json --lib` -> passed, 1 passed.
- `cargo test nl_issue_23_executable_incidence_fixtures_compare_preprocessing --test nl_integration` -> passed, 1 passed.
- `cargo test cli_writes_validated_json_report --test nl_integration` -> passed, 1 passed.
- `cargo test auxiliary_preprocessing --lib` -> passed, 73 passed.
- `cargo test --workspace` -> passed.
- `cargo nextest run` -> passed, 517 passed, 28 skipped. It emitted the existing warning about `.config/nextest.toml` containing unknown key `profile.default.slow-timeout.timeout`.
- `cargo test --doc` -> passed, 1 passed.
- `cargo build --release` -> passed.
- `make test-c` -> passed, all C API examples passed.

## Notes

- `cargo fmt --check` was tried, but the repository currently has broad pre-existing rustfmt drift in files outside this change set, so no repository-wide formatting pass was applied.

Closes #35.
