### PR TITLE
Add auxiliary preprocessing gates

### DIFF
--- a/docs/diagnostics-guide.md
+++ b/docs/diagnostics-guide.md
@@ -64,6 +64,7 @@ fields are:
 | Field | Meaning |
 |---|---|
 | `attempted`, `solved`, `failed` | Whether the phase ran, solved through preprocessing, or rejected/fell back |
+| `skipped`, `skip_reason` | Whether a no-op/cost gate skipped the phase before auxiliary solves, and why |
 | `total_time_secs` | Total wall-clock time spent in the phase |
 | `candidate_detection_time_secs` | Candidate search time, including incidence, filtering, and structural analysis |
 | `incidence_time_secs` | Time spent constructing equality-incidence data |
@@ -91,7 +92,9 @@ When preprocessing is slower than the no-preprocessing solve, compare
 `wall_time_secs` with the phase totals. High `candidate_detection_time_secs`
 points to structural overhead; high `auxiliary_solve_time_secs` or
 `recovery_solve_time_secs` points to internal block solves; high
-`reduced_solve_time_secs` means the reduced NLP itself still dominates.
+`reduced_solve_time_secs` means the reduced NLP itself still dominates. If
+`skipped` is true, `skip_reason` records the no-op or conservative cost gate
+that returned to the normal solve path before auxiliary block solves.
 
 ## Reading the diagnostics
 

--- a/docs/diagnostics-guide.md
+++ b/docs/diagnostics-guide.md
@@ -64,7 +64,7 @@ fields are:
 | Field | Meaning |
 |---|---|
 | `attempted`, `solved`, `failed` | Whether the phase ran, solved through preprocessing, or rejected/fell back |
-| `skipped`, `skip_reason` | Whether a no-op/cost gate skipped the phase before auxiliary solves, and why |
+| `skipped`, `skip_reason` | Whether the phase returned to the normal solve path before auxiliary solves, and why; examples include no accepted candidates, no-op gates, and cost gates |
 | `total_time_secs` | Total wall-clock time spent in the phase |
 | `candidate_detection_time_secs` | Candidate search time, including incidence, filtering, and structural analysis |
 | `incidence_time_secs` | Time spent constructing equality-incidence data |
@@ -93,8 +93,9 @@ When preprocessing is slower than the no-preprocessing solve, compare
 points to structural overhead; high `auxiliary_solve_time_secs` or
 `recovery_solve_time_secs` points to internal block solves; high
 `reduced_solve_time_secs` means the reduced NLP itself still dominates. If
-`skipped` is true, `skip_reason` records the no-op or conservative cost gate
-that returned to the normal solve path before auxiliary block solves.
+`skipped` is true, `skip_reason` records the no-candidate result, no-op gate,
+or conservative cost gate that returned to the normal solve path before
+auxiliary block solves.
 
 ## Reading the diagnostics
 

--- a/docs/src/diagnostics.md
+++ b/docs/src/diagnostics.md
@@ -63,7 +63,7 @@ structural data:
 | Field | Meaning |
 |---|---|
 | `attempted`, `solved`, `failed` | Whether the phase ran, solved the problem, or rejected/fell back |
-| `skipped`, `skip_reason` | Whether a no-op/cost gate skipped the phase before auxiliary solves, and why |
+| `skipped`, `skip_reason` | Whether the phase returned to the normal solve path before auxiliary solves, and why; examples include no accepted candidates, no-op gates, and cost gates |
 | `total_time_secs` | Total wall-clock time spent in that preprocessing phase |
 | `candidate_detection_time_secs` | End-to-end candidate search time |
 | `incidence_time_secs` | Time spent building equality incidence data |

--- a/docs/src/diagnostics.md
+++ b/docs/src/diagnostics.md
@@ -63,6 +63,7 @@ structural data:
 | Field | Meaning |
 |---|---|
 | `attempted`, `solved`, `failed` | Whether the phase ran, solved the problem, or rejected/fell back |
+| `skipped`, `skip_reason` | Whether a no-op/cost gate skipped the phase before auxiliary solves, and why |
 | `total_time_secs` | Total wall-clock time spent in that preprocessing phase |
 | `candidate_detection_time_secs` | End-to-end candidate search time |
 | `incidence_time_secs` | Time spent building equality incidence data |

--- a/src/auxiliary_preprocessing.rs
+++ b/src/auxiliary_preprocessing.rs
@@ -121,6 +121,8 @@ pub(crate) enum AuxiliaryRejectionReason {
     FullSpaceValidationFailure,
     ReductionDidNotRemoveAnything,
     NoBlocksSolved,
+    NoOpGate,
+    CostGate,
 }
 
 impl AuxiliaryRejectionReason {
@@ -143,6 +145,8 @@ impl AuxiliaryRejectionReason {
             Self::FullSpaceValidationFailure => "full-space validation failure",
             Self::ReductionDidNotRemoveAnything => "reduction did not remove anything",
             Self::NoBlocksSolved => "no blocks solved",
+            Self::NoOpGate => "no-op gate",
+            Self::CostGate => "cost gate",
         }
     }
 }

--- a/src/ipm.rs
+++ b/src/ipm.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::time::{Duration, Instant};
 
 use crate::convergence::{self, ConvergenceInfo, ConvergenceStatus};
@@ -2241,6 +2241,10 @@ enum AuxiliaryPreprocessAttempt {
     Failed,
 }
 
+const AUXILIARY_COST_GATE_MIN_PROBLEM_SIZE: usize = 1_000;
+const AUXILIARY_COST_GATE_MIN_CANDIDATES: usize = 64;
+const AUXILIARY_COST_GATE_MIN_BLOCKS: usize = 128;
+
 fn copy_auxiliary_candidate_diagnostics(
     target: &mut AuxiliaryPreprocessingDiagnostics,
     candidate_count: usize,
@@ -2300,6 +2304,81 @@ fn finish_auxiliary_diagnostics(
 ) {
     copy_auxiliary_candidate_diagnostics(target, candidate_count, diagnostics);
     target.total_time_secs += started.elapsed().as_secs_f64();
+}
+
+fn predicted_auxiliary_reduction(
+    candidates: &[crate::auxiliary_preprocessing::PresolveCandidate],
+) -> (usize, usize, usize) {
+    let mut rows = BTreeSet::new();
+    let mut vars = BTreeSet::new();
+    let mut blocks = 0;
+    for candidate in candidates {
+        for block in &candidate.blocks {
+            blocks += 1;
+            rows.extend(block.rows.iter().copied());
+            vars.extend(block.vars.iter().copied());
+        }
+    }
+    (rows.len(), vars.len(), blocks)
+}
+
+fn auxiliary_candidate_skip_reason(
+    problem_variables: usize,
+    problem_constraints: usize,
+    candidates: &[crate::auxiliary_preprocessing::PresolveCandidate],
+) -> Option<(crate::auxiliary_preprocessing::AuxiliaryRejectionReason, String)> {
+    let (predicted_rows, predicted_vars, predicted_blocks) =
+        predicted_auxiliary_reduction(candidates);
+    if predicted_rows == 0 || predicted_vars == 0 {
+        return Some((
+            crate::auxiliary_preprocessing::AuxiliaryRejectionReason::NoOpGate,
+            format!(
+                "predicted reduction removes {predicted_vars} variable(s) and {predicted_rows} constraint(s)"
+            ),
+        ));
+    }
+
+    let problem_size = problem_variables + problem_constraints;
+    if problem_size >= AUXILIARY_COST_GATE_MIN_PROBLEM_SIZE
+        && candidates.len() >= AUXILIARY_COST_GATE_MIN_CANDIDATES
+        && predicted_blocks >= AUXILIARY_COST_GATE_MIN_BLOCKS
+    {
+        return Some((
+            crate::auxiliary_preprocessing::AuxiliaryRejectionReason::CostGate,
+            format!(
+                "{} candidate group(s), {predicted_blocks} auxiliary block(s), predicted removal {} variable(s)/{} constraint(s), problem size {}x{}",
+                candidates.len(),
+                predicted_vars,
+                predicted_rows,
+                problem_variables,
+                problem_constraints,
+            ),
+        ));
+    }
+
+    None
+}
+
+fn skip_auxiliary_phase(
+    label: &str,
+    target: &mut AuxiliaryPreprocessingDiagnostics,
+    candidate_count: usize,
+    diagnostics: &mut crate::auxiliary_preprocessing::AuxiliaryCandidateDiagnostics,
+    reason: crate::auxiliary_preprocessing::AuxiliaryRejectionReason,
+    detail: String,
+    started: Instant,
+    options: &SolverOptions,
+) -> AuxiliaryPreprocessAttempt {
+    let reason_label = reason.label();
+    diagnostics.reject_global(reason, Some(detail.clone()));
+    target.skipped = true;
+    target.skip_reason = Some(format!("{reason_label}: {detail}"));
+    if options.print_level >= 5 {
+        diagnostics.log_verbose(label);
+        rip_log!("ripopt: {label} skipped by {reason_label}: {detail}");
+    }
+    finish_auxiliary_diagnostics(target, candidate_count, diagnostics, started);
+    AuxiliaryPreprocessAttempt::NoCandidates
 }
 
 struct FullSpaceValidation {
@@ -2482,11 +2561,31 @@ fn try_auxiliary_preprocessed_solve<P: NlpProblem>(
         );
     phase.candidate_detection_time_secs += candidate_start.elapsed().as_secs_f64();
     if candidates.is_empty() {
+        phase.skipped = true;
+        phase.skip_reason = Some("no accepted auxiliary candidates".to_string());
         if options.print_level >= 5 && diagnostics.equality_rows > 0 {
             diagnostics.log_verbose("Auxiliary preprocessing");
+            rip_log!("ripopt: Auxiliary preprocessing skipped: no accepted auxiliary candidates");
         }
         finish_auxiliary_diagnostics(phase, candidates.len(), &diagnostics, phase_start);
         return AuxiliaryPreprocessAttempt::NoCandidates;
+    }
+
+    if let Some((reason, detail)) = auxiliary_candidate_skip_reason(
+        problem.num_variables(),
+        problem.num_constraints(),
+        &candidates,
+    ) {
+        return skip_auxiliary_phase(
+            "Auxiliary preprocessing",
+            phase,
+            candidates.len(),
+            &mut diagnostics,
+            reason,
+            detail,
+            phase_start,
+            options,
+        );
     }
 
     let Some(preprocess_opts) = auxiliary_preprocessing_options(options, solve_start) else {
@@ -2708,11 +2807,31 @@ fn try_auxiliary_postsolve_solve<P: NlpProblem>(
         );
     phase.candidate_detection_time_secs += candidate_start.elapsed().as_secs_f64();
     if candidates.is_empty() {
+        phase.skipped = true;
+        phase.skip_reason = Some("no accepted auxiliary postsolve candidates".to_string());
         if options.print_level >= 5 && diagnostics.equality_rows > 0 {
             diagnostics.log_verbose("Auxiliary postsolve");
+            rip_log!("ripopt: Auxiliary postsolve skipped: no accepted auxiliary candidates");
         }
         finish_auxiliary_diagnostics(phase, candidates.len(), &diagnostics, phase_start);
         return AuxiliaryPreprocessAttempt::NoCandidates;
+    }
+
+    if let Some((reason, detail)) = auxiliary_candidate_skip_reason(
+        problem.num_variables(),
+        problem.num_constraints(),
+        &candidates,
+    ) {
+        return skip_auxiliary_phase(
+            "Auxiliary postsolve",
+            phase,
+            candidates.len(),
+            &mut diagnostics,
+            reason,
+            detail,
+            phase_start,
+            options,
+        );
     }
 
     let Some(preprocess_opts) = auxiliary_preprocessing_options(options, solve_start) else {
@@ -12063,6 +12182,99 @@ mod tests {
         }
     }
 
+    struct ManyIndependentAuxiliaryBlocksProblem {
+        total_variables: usize,
+        equality_blocks: usize,
+    }
+
+    impl NlpProblem for ManyIndependentAuxiliaryBlocksProblem {
+        fn num_variables(&self) -> usize { self.total_variables }
+        fn num_constraints(&self) -> usize { self.equality_blocks }
+
+        fn bounds(&self, x_l: &mut [f64], x_u: &mut [f64]) {
+            x_l.fill(f64::NEG_INFINITY);
+            x_u.fill(f64::INFINITY);
+        }
+
+        fn constraint_bounds(&self, g_l: &mut [f64], g_u: &mut [f64]) {
+            for row in 0..self.equality_blocks {
+                g_l[row] = 0.0;
+                g_u[row] = 0.0;
+            }
+        }
+
+        fn initial_point(&self, x0: &mut [f64]) {
+            x0.fill(0.0);
+        }
+
+        fn objective(&self, _x: &[f64], _new_x: bool, obj: &mut f64) -> bool {
+            *obj = 0.0;
+            true
+        }
+
+        fn gradient(&self, _x: &[f64], _new_x: bool, grad: &mut [f64]) -> bool {
+            grad.fill(0.0);
+            true
+        }
+
+        fn constraints(&self, x: &[f64], _new_x: bool, g: &mut [f64]) -> bool {
+            for row in 0..self.equality_blocks {
+                g[row] = x[row] - 1.0;
+            }
+            true
+        }
+
+        fn jacobian_structure(&self) -> (Vec<usize>, Vec<usize>) {
+            (
+                (0..self.equality_blocks).collect(),
+                (0..self.equality_blocks).collect(),
+            )
+        }
+
+        fn jacobian_values(&self, _x: &[f64], _new_x: bool, vals: &mut [f64]) -> bool {
+            vals.fill(1.0);
+            true
+        }
+
+        fn hessian_structure(&self) -> (Vec<usize>, Vec<usize>) {
+            (Vec::new(), Vec::new())
+        }
+
+        fn hessian_values(
+            &self,
+            _x: &[f64],
+            _new_x: bool,
+            _obj_factor: f64,
+            _lambda: &[f64],
+            _vals: &mut [f64],
+        ) -> bool {
+            true
+        }
+    }
+
+    fn candidate_shape(
+        candidate_count: usize,
+        block_count: usize,
+    ) -> Vec<crate::auxiliary_preprocessing::PresolveCandidate> {
+        let mut candidates = Vec::new();
+        let mut next = 0;
+        for candidate_index in 0..candidate_count {
+            let remaining_candidates = candidate_count - candidate_index;
+            let remaining_blocks = block_count - next;
+            let blocks_this_candidate = remaining_blocks.div_ceil(remaining_candidates);
+            let mut blocks = Vec::new();
+            for _ in 0..blocks_this_candidate {
+                blocks.push(crate::auxiliary_preprocessing::EqualityBlock {
+                    rows: vec![next],
+                    vars: vec![next],
+                });
+                next += 1;
+            }
+            candidates.push(crate::auxiliary_preprocessing::PresolveCandidate { blocks });
+        }
+        candidates
+    }
+
     unsafe extern "C" fn capture_log(msg: *const c_char, user_data: *mut c_void) {
         let logs = &mut *(user_data as *mut Vec<String>);
         logs.push(CStr::from_ptr(msg).to_string_lossy().into_owned());
@@ -12076,7 +12288,7 @@ mod tests {
             max_iter: 100,
             ..SolverOptions::default()
         };
-        let mut logs = Vec::new();
+        let mut logs: Vec<String> = Vec::new();
         crate::logging::set_log_callback(Some((
             capture_log,
             &mut logs as *mut Vec<String> as *mut c_void,
@@ -12178,6 +12390,99 @@ mod tests {
         let attempt_opts = auxiliary_preprocessing_options(&options, Instant::now());
 
         assert!(attempt_opts.is_none());
+    }
+
+    #[test]
+    fn auxiliary_cost_gate_matches_known_preprocessing_shapes() {
+        let issue_23 = candidate_shape(1, 13);
+        assert!(auxiliary_candidate_skip_reason(19, 19, &issue_23).is_none());
+
+        let gaslib11_steady = candidate_shape(2, 52);
+        assert!(auxiliary_candidate_skip_reason(204, 200, &gaslib11_steady).is_none());
+
+        let gaslib40_steady = candidate_shape(16, 86);
+        assert!(auxiliary_candidate_skip_reason(1694, 1682, &gaslib40_steady).is_none());
+
+        let gaslib11_dynamic_shape = candidate_shape(106, 278);
+        let skip = auxiliary_candidate_skip_reason(2542, 2492, &gaslib11_dynamic_shape)
+            .expect("large many-block dynamic gas shape should trip the cost gate");
+        assert_eq!(
+            skip.0.label(),
+            crate::auxiliary_preprocessing::AuxiliaryRejectionReason::CostGate.label()
+        );
+        assert!(skip.1.contains("106 candidate group"));
+        assert!(skip.1.contains("278 auxiliary block"));
+    }
+
+    #[test]
+    fn auxiliary_cost_gate_skips_many_blocks_before_auxiliary_solves() {
+        let problem = ManyIndependentAuxiliaryBlocksProblem {
+            total_variables: 1_000,
+            equality_blocks: 130,
+        };
+        let options = SolverOptions {
+            print_level: 0,
+            enable_preprocessing: true,
+            max_iter: 100,
+            ..SolverOptions::default()
+        };
+
+        let mut phase = AuxiliaryPreprocessingDiagnostics::default();
+        let attempt =
+            try_auxiliary_preprocessed_solve(&problem, &options, Instant::now(), &mut phase);
+
+        assert!(matches!(attempt, AuxiliaryPreprocessAttempt::NoCandidates));
+        assert!(phase.skipped);
+        assert!(
+            phase
+                .skip_reason
+                .as_deref()
+                .is_some_and(|reason| reason.contains("cost gate")),
+            "skip_reason={:?}",
+            phase.skip_reason
+        );
+        assert_eq!(phase.candidates, 130);
+        assert_eq!(phase.btd_blocks, 130);
+        assert_eq!(phase.auxiliary_blocks_solved, 0);
+        assert_eq!(phase.auxiliary_iterations, 0);
+        assert_eq!(phase.auxiliary_solve_time_secs, 0.0);
+        assert!(
+            phase
+                .rejection_counts
+                .iter()
+                .any(|entry| entry.reason == "cost gate" && entry.count == 1),
+            "rejection_counts={:?}",
+            phase.rejection_counts
+        );
+    }
+
+    #[test]
+    fn auxiliary_cost_gate_logs_verbose_skip_reason() {
+        let problem = ManyIndependentAuxiliaryBlocksProblem {
+            total_variables: 1_000,
+            equality_blocks: 130,
+        };
+        let options = SolverOptions {
+            print_level: 5,
+            enable_preprocessing: true,
+            max_iter: 100,
+            ..SolverOptions::default()
+        };
+
+        let mut logs: Vec<String> = Vec::new();
+        crate::logging::set_log_callback(Some((
+            capture_log,
+            &mut logs as *mut Vec<String> as *mut c_void,
+        )));
+        let mut phase = AuxiliaryPreprocessingDiagnostics::default();
+        let _ = try_auxiliary_preprocessed_solve(&problem, &options, Instant::now(), &mut phase);
+        crate::logging::set_log_callback(None);
+
+        assert!(
+            logs.iter()
+                .any(|line| line.contains("Auxiliary preprocessing skipped by cost gate")),
+            "logs={logs:?}"
+        );
     }
 
     #[test]

--- a/src/ipm.rs
+++ b/src/ipm.rs
@@ -2244,6 +2244,7 @@ enum AuxiliaryPreprocessAttempt {
 const AUXILIARY_COST_GATE_MIN_PROBLEM_SIZE: usize = 1_000;
 const AUXILIARY_COST_GATE_MIN_CANDIDATES: usize = 64;
 const AUXILIARY_COST_GATE_MIN_BLOCKS: usize = 128;
+const AUXILIARY_COST_GATE_MAX_REMOVAL_FRACTION: f64 = 0.25;
 
 fn copy_auxiliary_candidate_diagnostics(
     target: &mut AuxiliaryPreprocessingDiagnostics,
@@ -2322,6 +2323,25 @@ fn predicted_auxiliary_reduction(
     (rows.len(), vars.len(), blocks)
 }
 
+fn predicted_auxiliary_removal_fraction(
+    problem_variables: usize,
+    problem_constraints: usize,
+    predicted_vars: usize,
+    predicted_rows: usize,
+) -> f64 {
+    let variable_fraction = if problem_variables > 0 {
+        predicted_vars as f64 / problem_variables as f64
+    } else {
+        0.0
+    };
+    let constraint_fraction = if problem_constraints > 0 {
+        predicted_rows as f64 / problem_constraints as f64
+    } else {
+        0.0
+    };
+    variable_fraction.min(constraint_fraction)
+}
+
 fn auxiliary_candidate_skip_reason(
     problem_variables: usize,
     problem_constraints: usize,
@@ -2339,17 +2359,25 @@ fn auxiliary_candidate_skip_reason(
     }
 
     let problem_size = problem_variables + problem_constraints;
+    let predicted_removal_fraction = predicted_auxiliary_removal_fraction(
+        problem_variables,
+        problem_constraints,
+        predicted_vars,
+        predicted_rows,
+    );
     if problem_size >= AUXILIARY_COST_GATE_MIN_PROBLEM_SIZE
         && candidates.len() >= AUXILIARY_COST_GATE_MIN_CANDIDATES
         && predicted_blocks >= AUXILIARY_COST_GATE_MIN_BLOCKS
+        && predicted_removal_fraction < AUXILIARY_COST_GATE_MAX_REMOVAL_FRACTION
     {
         return Some((
             crate::auxiliary_preprocessing::AuxiliaryRejectionReason::CostGate,
             format!(
-                "{} candidate group(s), {predicted_blocks} auxiliary block(s), predicted removal {} variable(s)/{} constraint(s), problem size {}x{}",
+                "{} candidate group(s), {predicted_blocks} auxiliary block(s), predicted removal {} variable(s)/{} constraint(s) ({:.1}% of dimensions), problem size {}x{}",
                 candidates.len(),
                 predicted_vars,
                 predicted_rows,
+                100.0 * predicted_removal_fraction,
                 problem_variables,
                 problem_constraints,
             ),
@@ -12412,6 +12440,16 @@ mod tests {
         );
         assert!(skip.1.contains("106 candidate group"));
         assert!(skip.1.contains("278 auxiliary block"));
+    }
+
+    #[test]
+    fn auxiliary_cost_gate_allows_large_useful_many_block_reduction() {
+        let useful_many_block_shape = candidate_shape(900, 900);
+
+        assert!(
+            auxiliary_candidate_skip_reason(1_000, 1_000, &useful_many_block_shape).is_none(),
+            "large many-block reductions that remove most dimensions should be attempted"
+        );
     }
 
     #[test]

--- a/src/result.rs
+++ b/src/result.rs
@@ -14,6 +14,8 @@ pub struct AuxiliaryPreprocessingDiagnostics {
     pub attempted: bool,
     pub solved: bool,
     pub failed: bool,
+    pub skipped: bool,
+    pub skip_reason: Option<String>,
     pub total_time_secs: f64,
     pub candidate_detection_time_secs: f64,
     pub incidence_time_secs: f64,


### PR DESCRIPTION
## Summary

- Adds conservative auxiliary preprocessing no-op/cost gates before auxiliary block solves.
- Records `skipped` and `skip_reason` in auxiliary preprocessing diagnostics and verbose logs.
- Skips the known `gaslib11_dynamic.nl` many-block/no-reduction signature before auxiliary solves, returning to the normal original-NLP solve path.
- Keeps known useful reductions below the gate threshold, including issue #23 fixtures and steady gas cases.
- Documents the new `skipped` and `skip_reason` diagnostics fields.

## Tests run

- `cargo test auxiliary_cost_gate --lib` -> passed, 3 passed.
- `cargo test auxiliary_preprocessing --lib` -> passed, 73 passed.
- `cargo test nl_issue_23_executable_incidence_fixtures_compare_preprocessing --test nl_integration` -> passed, 1 passed.
- `cargo test report_serializes_to_json --lib` -> passed, 1 passed.
- `cargo build --release` -> passed.
- `target/release/ripopt benchmarks/gas/gaslib11_dynamic.nl -o /tmp/ripopt-issue36-after-dynamic-pre.json print_level=0 enable_preprocessing=yes max_iter=3000` -> passed, `Optimal`, 20 iterations, 1.276s solver wall time, presolve `skipped=true`, `skip_reason` starts with `cost gate`, auxiliary solve time 0.0s.
- `target/release/ripopt benchmarks/gas/gaslib11_dynamic.nl -o /tmp/ripopt-issue36-after-dynamic-no.json print_level=0 enable_preprocessing=no max_iter=3000` -> passed, `Optimal`, 20 iterations, 1.240s solver wall time.
- `target/release/ripopt benchmarks/gas/gaslib11_steady.nl -o /tmp/ripopt-issue36-after-gas11-steady.json print_level=0 enable_preprocessing=yes max_iter=3000` -> passed, `Optimal`, 17 iterations, presolve solved with 64 variables/constraints removed.
- `target/release/ripopt benchmarks/gas/gaslib40_steady.nl -o /tmp/ripopt-issue36-after-gas40-steady.json print_level=0 enable_preprocessing=yes max_iter=3000` -> passed, `Optimal`, 66 iterations, presolve solved with 86 variables/constraints removed.
- `target/release/ripopt tests/fixtures/issue_23/tutorial_flow_density.nl -o /tmp/ripopt-issue36-after-issue23.json print_level=0 enable_preprocessing=yes max_iter=500` -> passed, `Optimal`, 0 iterations, presolve solved with 19 variables/constraints removed.
- `git diff --check` -> passed.
- `cargo nextest run` -> passed, 520 passed, 28 skipped. It emitted the existing warning about unknown key `profile.default.slow-timeout.timeout` in `.config/nextest.toml`.
- `cargo test --doc` -> passed, 1 passed.
- `make test-c` -> passed, all C API examples passed.

## Notes

- No tests were intentionally skipped beyond the existing ignored/skipped tests reported by nextest.

Closes #36.
